### PR TITLE
Adds initial implementation of the JWT package

### DIFF
--- a/jwt/algs.go
+++ b/jwt/algs.go
@@ -1,0 +1,33 @@
+package jwt
+
+// Alg represents asymmetric signing algorithms
+type Alg string
+
+const (
+	// JOSE asymmetric signing algorithm values as defined by RFC 7518.
+	//
+	// See: https://tools.ietf.org/html/rfc7518#section-3.1
+	RS256 Alg = "RS256" // RSASSA-PKCS-v1.5 using SHA-256
+	RS384 Alg = "RS384" // RSASSA-PKCS-v1.5 using SHA-384
+	RS512 Alg = "RS512" // RSASSA-PKCS-v1.5 using SHA-512
+	ES256 Alg = "ES256" // ECDSA using P-256 and SHA-256
+	ES384 Alg = "ES384" // ECDSA using P-384 and SHA-384
+	ES512 Alg = "ES512" // ECDSA using P-521 and SHA-512
+	PS256 Alg = "PS256" // RSASSA-PSS using SHA256 and MGF1-SHA256
+	PS384 Alg = "PS384" // RSASSA-PSS using SHA384 and MGF1-SHA384
+	PS512 Alg = "PS512" // RSASSA-PSS using SHA512 and MGF1-SHA512
+	EdDSA Alg = "EdDSA" // Ed25519 using SHA-512
+)
+
+var supportedAlgorithms = map[Alg]bool{
+	RS256: true,
+	RS384: true,
+	RS512: true,
+	ES256: true,
+	ES384: true,
+	ES512: true,
+	PS256: true,
+	PS384: true,
+	PS512: true,
+	EdDSA: true,
+}

--- a/jwt/algs.go
+++ b/jwt/algs.go
@@ -1,5 +1,7 @@
 package jwt
 
+import "fmt"
+
 // Alg represents asymmetric signing algorithms
 type Alg string
 
@@ -30,4 +32,15 @@ var supportedAlgorithms = map[Alg]bool{
 	PS384: true,
 	PS512: true,
 	EdDSA: true,
+}
+
+// SupportedSigningAlgorithm returns an error if any of the given Algs
+// are not supported signing algorithms.
+func SupportedSigningAlgorithm(algs ...Alg) error {
+	for _, a := range algs {
+		if !supportedAlgorithms[a] {
+			return fmt.Errorf("unsupported signing algorithm %q", a)
+		}
+	}
+	return nil
 }

--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -1,0 +1,30 @@
+/*
+Package jwt provides signature verification and claims set validation for JSON Web Tokens (JWT)
+of the JSON Web Signature (JWS) form.
+
+JWT claims set validation provided by the package includes the option to validate
+all registered claim names defined in https://tools.ietf.org/html/rfc7519#section-4.1.
+
+JOSE header validation provided by the the package includes the option to validate the "alg"
+(Algorithm) Header Parameter defined in https://tools.ietf.org/html/rfc7515#section-4.1.
+
+JWT signature verification is supported by providing keys from the following sources:
+
+ - JSON Web Key Set (JWKS) URL
+ - OIDC Discovery mechanism
+ - Local PEM-encoded public keys
+
+JWT signature verification supports the following asymmetric algorithms as defined in
+https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1:
+
+ - RS256: RSASSA-PKCS1-v1_5 using SHA-256
+ - RS384: RSASSA-PKCS1-v1_5 using SHA-384
+ - RS512: RSASSA-PKCS1-v1_5 using SHA-512
+ - ES256: ECDSA using P-256 and SHA-256
+ - ES384: ECDSA using P-384 and SHA-384
+ - ES512: ECDSA using P-521 and SHA-512
+ - PS256: RSASSA-PSS using SHA-256 and MGF1 with SHA-256
+ - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
+ - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
+*/
+package jwt

--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -12,7 +12,7 @@ JWT signature verification is supported by providing keys from the following sou
 
  - JSON Web Key Set (JWKS) URL
  - OIDC Discovery mechanism
- - Local PEM-encoded public keys
+ - Local public keys
 
 JWT signature verification supports the following asymmetric algorithms as defined in
 https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1:

--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -26,5 +26,6 @@ https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1:
  - PS256: RSASSA-PSS using SHA-256 and MGF1 with SHA-256
  - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
  - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
+ - EdDSA: Ed25519 using SHA-512
 */
 package jwt

--- a/jwt/doc_test.go
+++ b/jwt/doc_test.go
@@ -29,7 +29,7 @@ func ExampleValidator_Validate() {
 		Subject:           "your_expected_subject",
 		ID:                "your_expected_jwt_id",
 		Audiences:         []string{"your_expected_audiences"},
-		SigningAlgorithms: []string{"your_expected_signing_algs"},
+		SigningAlgorithms: []jwt.Alg{jwt.RS256},
 	}
 
 	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJleHBfaXNzIiwiZXhwIjoxNTI2MjM5MDIyfQ.XG1xYJcuPMfgu8xkMzVjkYK2WIUyl4-A1Zq1j4Dfr99-PJUN36ZAgi8Fj08modiexXETrg05MqSxkJAE5Czns1IhqEEypx6xfYHSINp0SLKxBFHPA4BCi0IW83T-e225JjjVEGFR_Wo8QM6Rc-qQVJ9bqwKD4kcbQeMACkgGFcgNurtNkOM9vtOEs0Pe9tb4nHYw4ef1stCytTi9GFZwGoHQf0pjpWCpjlxaFIR4vmHQ4YB3w29o_tKN6zqyA2FITnvkzGnaLvdPecJNskRSCPUTRfYcVVNXCOnCvTdpvwK-c4nCs5yGnw3eeFoT6mhQSp39KYti1MpHNQTYwZrLTA"

--- a/jwt/doc_test.go
+++ b/jwt/doc_test.go
@@ -2,6 +2,9 @@ package jwt_test
 
 import (
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 	"log"
 
@@ -75,19 +78,16 @@ func ExampleNewOIDCDiscoveryKeySet() {
 func ExampleNewStaticKeySet() {
 	ctx := context.Background()
 
-	pubKeys := []string{
-		`-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
-vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
-aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
-tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
-e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
-V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
-MwIDAQAB
------END PUBLIC KEY-----`,
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	keySet, err := jwt.NewStaticKeySet(pubKeys)
+	keys := []crypto.PublicKey{
+		rsaKey.Public(),
+	}
+
+	keySet, err := jwt.NewStaticKeySet(keys)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/jwt/doc_test.go
+++ b/jwt/doc_test.go
@@ -61,7 +61,7 @@ func ExampleNewJSONWebKeySet() {
 func ExampleNewOIDCDiscoveryKeySet() {
 	ctx := context.Background()
 
-	keySet, err := jwt.NewOIDCDiscoveryKeySet(ctx, "your_oidc_discovery_url", "your_oidc_discovery_ca_pem")
+	keySet, err := jwt.NewOIDCDiscoveryKeySet(ctx, "your_issuer_url", "your_issuer_ca_pem")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/jwt/doc_test.go
+++ b/jwt/doc_test.go
@@ -1,0 +1,102 @@
+package jwt_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/cap/jwt"
+)
+
+func ExampleValidator_Validate() {
+	ctx := context.Background()
+
+	keySet, err := jwt.NewJSONWebKeySet(ctx, "your_jwks_url", "your_jwks_ca_pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	validator, err := jwt.NewValidator(keySet)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expected := jwt.Expected{
+		Issuer:            "your_expected_issuer",
+		Subject:           "your_expected_subject",
+		ID:                "your_expected_jwt_id",
+		Audiences:         []string{"your_expected_audiences"},
+		SigningAlgorithms: []string{"your_expected_signing_algs"},
+	}
+
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJleHBfaXNzIiwiZXhwIjoxNTI2MjM5MDIyfQ.XG1xYJcuPMfgu8xkMzVjkYK2WIUyl4-A1Zq1j4Dfr99-PJUN36ZAgi8Fj08modiexXETrg05MqSxkJAE5Czns1IhqEEypx6xfYHSINp0SLKxBFHPA4BCi0IW83T-e225JjjVEGFR_Wo8QM6Rc-qQVJ9bqwKD4kcbQeMACkgGFcgNurtNkOM9vtOEs0Pe9tb4nHYw4ef1stCytTi9GFZwGoHQf0pjpWCpjlxaFIR4vmHQ4YB3w29o_tKN6zqyA2FITnvkzGnaLvdPecJNskRSCPUTRfYcVVNXCOnCvTdpvwK-c4nCs5yGnw3eeFoT6mhQSp39KYti1MpHNQTYwZrLTA"
+	claims, err := validator.Validate(ctx, token, expected)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(claims)
+}
+
+func ExampleNewJSONWebKeySet() {
+	ctx := context.Background()
+
+	keySet, err := jwt.NewJSONWebKeySet(ctx, "your_jwks_url", "your_jwks_ca_pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJleHBfaXNzIiwiZXhwIjoxNTI2MjM5MDIyfQ.XG1xYJcuPMfgu8xkMzVjkYK2WIUyl4-A1Zq1j4Dfr99-PJUN36ZAgi8Fj08modiexXETrg05MqSxkJAE5Czns1IhqEEypx6xfYHSINp0SLKxBFHPA4BCi0IW83T-e225JjjVEGFR_Wo8QM6Rc-qQVJ9bqwKD4kcbQeMACkgGFcgNurtNkOM9vtOEs0Pe9tb4nHYw4ef1stCytTi9GFZwGoHQf0pjpWCpjlxaFIR4vmHQ4YB3w29o_tKN6zqyA2FITnvkzGnaLvdPecJNskRSCPUTRfYcVVNXCOnCvTdpvwK-c4nCs5yGnw3eeFoT6mhQSp39KYti1MpHNQTYwZrLTA"
+	claims, err := keySet.VerifySignature(ctx, token)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(claims)
+}
+
+func ExampleNewOIDCDiscoveryKeySet() {
+	ctx := context.Background()
+
+	keySet, err := jwt.NewOIDCDiscoveryKeySet(ctx, "your_oidc_discovery_url", "your_oidc_discovery_ca_pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJleHBfaXNzIiwiZXhwIjoxNTI2MjM5MDIyfQ.XG1xYJcuPMfgu8xkMzVjkYK2WIUyl4-A1Zq1j4Dfr99-PJUN36ZAgi8Fj08modiexXETrg05MqSxkJAE5Czns1IhqEEypx6xfYHSINp0SLKxBFHPA4BCi0IW83T-e225JjjVEGFR_Wo8QM6Rc-qQVJ9bqwKD4kcbQeMACkgGFcgNurtNkOM9vtOEs0Pe9tb4nHYw4ef1stCytTi9GFZwGoHQf0pjpWCpjlxaFIR4vmHQ4YB3w29o_tKN6zqyA2FITnvkzGnaLvdPecJNskRSCPUTRfYcVVNXCOnCvTdpvwK-c4nCs5yGnw3eeFoT6mhQSp39KYti1MpHNQTYwZrLTA"
+	claims, err := keySet.VerifySignature(ctx, token)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(claims)
+}
+
+func ExampleNewStaticKeySet() {
+	ctx := context.Background()
+
+	pubKeys := []string{
+		`-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
+vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
+aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
+tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
+e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
+V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
+MwIDAQAB
+-----END PUBLIC KEY-----`,
+	}
+
+	keySet, err := jwt.NewStaticKeySet(pubKeys)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJleHBfaXNzIiwiZXhwIjoxNTI2MjM5MDIyfQ.XG1xYJcuPMfgu8xkMzVjkYK2WIUyl4-A1Zq1j4Dfr99-PJUN36ZAgi8Fj08modiexXETrg05MqSxkJAE5Czns1IhqEEypx6xfYHSINp0SLKxBFHPA4BCi0IW83T-e225JjjVEGFR_Wo8QM6Rc-qQVJ9bqwKD4kcbQeMACkgGFcgNurtNkOM9vtOEs0Pe9tb4nHYw4ef1stCytTi9GFZwGoHQf0pjpWCpjlxaFIR4vmHQ4YB3w29o_tKN6zqyA2FITnvkzGnaLvdPecJNskRSCPUTRfYcVVNXCOnCvTdpvwK-c4nCs5yGnw3eeFoT6mhQSp39KYti1MpHNQTYwZrLTA"
+	claims, err := keySet.VerifySignature(ctx, token)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(claims)
+}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -89,7 +89,8 @@ type Expected struct {
 //  3. It's valid with respect to the current time. This means that the current
 //     time must be within the times (inclusive) given by the "nbf" (Not Before)
 //     and "exp" (Expiration Time) claims and after the time given by the "iat"
-//     (Issued At) claim, with configurable leeway.
+//     (Issued At) claim, with configurable leeway. See Expected.Now() for details
+//     on how the current time is provided for validation.
 func (v *Validator) Validate(ctx context.Context, token string, expected Expected) (map[string]interface{}, error) {
 	// First, verify the signature to ensure subsequent validation is against verified claims
 	allClaims, err := v.keySet.VerifySignature(ctx, token)

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,0 +1,259 @@
+package jwt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+const (
+	defaultLeewaySeconds = 150
+)
+
+// Validator validates JSON Web Tokens (JWT) by providing signature
+// verification and claims set validation.
+type Validator struct {
+	keySet KeySet
+}
+
+// NewValidator returns a Validator that uses the given KeySet to verify JWT signatures.
+func NewValidator(keySet KeySet) (*Validator, error) {
+	if keySet == nil {
+		return nil, errors.New("keySet must not be nil")
+	}
+
+	return &Validator{
+		keySet: keySet,
+	}, nil
+}
+
+// Expected defines the expected claims values to assert when validating a JWT.
+// For claims that involve validation of the JWT with respect to time, leeway
+// fields are provided to account for potential clock skew.
+type Expected struct {
+	// The expected JWT "iss" (issuer) claim value. If empty, validation is skipped.
+	Issuer string
+
+	// The expected JWT "sub" (subject) claim value. If empty, validation is skipped.
+	Subject string
+
+	// The expected JWT "jti" (JWT ID) claim value. If empty, validation is skipped.
+	ID string
+
+	// The list of expected JWT "aud" (audience) claim values to match against.
+	// The JWT claim will be considered valid if it matches any of the expected
+	// audiences. If there are no expected audiences, then the presence of any
+	// audience in the JWT will render it invalid.
+	Audiences []string
+
+	// SigningAlgorithms provides the list of expected JWS "alg" (algorithm) header
+	// parameter values to match against. The JWS header parameter will be considered
+	// valid if it matches any of the expected signing algorithms. If empty, defaults
+	// to "RS256" as defined in https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1.
+	SigningAlgorithms []string
+
+	// NotBeforeLeeway provides the option to set an amount of leeway to use when
+	// validating the "nbf" (Not Before) claim. If the duration is zero or not
+	// provided, a default leeway of 150 seconds will be used. If the duration is
+	// negative, no leeway will be used.
+	NotBeforeLeeway time.Duration
+
+	// ExpirationLeeway provides the option to set an amount of leeway to use when
+	// validating the "exp" (Expiration Time) claim. If the duration is zero or not
+	// provided, a default leeway of 150 seconds will be used. If the duration is
+	// negative, no leeway will be used.
+	ExpirationLeeway time.Duration
+
+	// ClockSkewLeeway provides the option to set an amount of leeway to use when
+	// validating the "nbf" (Not Before), "exp" (Expiration Time), and "iat" (Issued At)
+	// claims. If the duration is zero or not provided, a default leeway of 60 seconds
+	// will be used. If the duration is negative, no leeway will be used.
+	ClockSkewLeeway time.Duration
+
+	// Now provides the option to specify a func for determining what the current time is.
+	// The func will be used to provide the current time when validating a JWT with respect to
+	// the "nbf" (Not Before), "exp" (Expiration Time), and "iat" (Issued At) claims. If not
+	// provided, defaults to returning time.Now().
+	Now func() time.Time
+}
+
+// Validate validates JWTs of the JWS compact serialization form.
+//
+// The given JWT is considered valid if:
+//  1. Its signature is successfully verified.
+//  2. Its claims set and header parameter values match what's given by Expected.
+//  3. It's valid with respect to the current time. This means that the current
+//     time must be within the times (inclusive) given by the "nbf" (Not Before)
+//     and "exp" (Expiration Time) claims and after the time given by the "iat"
+//     (Issued At) claim, with configurable leeway.
+func (v *Validator) Validate(ctx context.Context, token string, expected Expected) (map[string]interface{}, error) {
+	// First, verify the signature to ensure subsequent validation is against verified claims
+	allClaims, err := v.keySet.VerifySignature(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("error verifying token signature: %w", err)
+	}
+
+	// Validate the signing algorithm in the JWS header
+	if err := validateSigningAlgorithm(token, expected.SigningAlgorithms); err != nil {
+		return nil, fmt.Errorf("invalid algorithm (alg) header parameter: %w", err)
+	}
+
+	// Unmarshal all claims into the set of public JWT registered claims
+	claims := jwt.Claims{}
+	allClaimsJSON, err := json.Marshal(allClaims)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(allClaimsJSON, &claims); err != nil {
+		return nil, err
+	}
+
+	// At least one of the "nbf" (Not Before), "exp" (Expiration Time), or "iat" (Issued At)
+	// claims are required to be set.
+	if claims.IssuedAt == nil {
+		claims.IssuedAt = new(jwt.NumericDate)
+	}
+	if claims.Expiry == nil {
+		claims.Expiry = new(jwt.NumericDate)
+	}
+	if claims.NotBefore == nil {
+		claims.NotBefore = new(jwt.NumericDate)
+	}
+	if *claims.IssuedAt == 0 && *claims.Expiry == 0 && *claims.NotBefore == 0 {
+		return nil, errors.New("no issued at (iat), not before (nbf), or expiration time (exp) claims in token")
+	}
+
+	// If "exp" (Expiration Time) is not set, then set it to the latest of
+	// either the "iat" (Issued At) or "nbf" (Not Before) claims plus leeway.
+	if *claims.Expiry == 0 {
+		latestStart := *claims.IssuedAt
+		if *claims.NotBefore > *claims.IssuedAt {
+			latestStart = *claims.NotBefore
+		}
+		leeway := expected.ExpirationLeeway.Seconds()
+		if expected.ExpirationLeeway.Seconds() < 0 {
+			leeway = 0
+		} else if expected.ExpirationLeeway.Seconds() == 0 {
+			leeway = defaultLeewaySeconds
+		}
+		*claims.Expiry = jwt.NumericDate(int64(latestStart) + int64(leeway))
+	}
+
+	// If "nbf" (Not Before) is not set, then set it to the "iat" (Issued At) if set.
+	// Otherwise, set it to the "exp" (Expiration Time) minus leeway.
+	if *claims.NotBefore == 0 {
+		if *claims.IssuedAt != 0 {
+			*claims.NotBefore = *claims.IssuedAt
+		} else {
+			leeway := expected.NotBeforeLeeway.Seconds()
+			if expected.NotBeforeLeeway.Seconds() < 0 {
+				leeway = 0
+			} else if expected.NotBeforeLeeway.Seconds() == 0 {
+				leeway = defaultLeewaySeconds
+			}
+			*claims.NotBefore = jwt.NumericDate(int64(*claims.Expiry) - int64(leeway))
+		}
+	}
+
+	// Set clock skew leeway to apply when validating all time-related claims
+	cksLeeway := expected.ClockSkewLeeway
+	if expected.ClockSkewLeeway.Seconds() < 0 {
+		cksLeeway = 0
+	} else if expected.ClockSkewLeeway.Seconds() == 0 {
+		cksLeeway = jwt.DefaultLeeway
+	}
+
+	// Validate claims by asserting they're as expected
+	if expected.Issuer != "" && expected.Issuer != claims.Issuer {
+		return nil, fmt.Errorf("invalid issuer (iss) claim")
+	}
+	if expected.Subject != "" && expected.Subject != claims.Subject {
+		return nil, fmt.Errorf("invalid subject (sub) claim")
+	}
+	if expected.ID != "" && expected.ID != claims.ID {
+		return nil, fmt.Errorf("invalid ID (jti) claim")
+	}
+	if err := validateAudience(expected.Audiences, claims.Audience); err != nil {
+		return nil, fmt.Errorf("invalid audience (aud) claim: %w", err)
+	}
+
+	// Validate that the token is not expired with respect to the current time
+	now := time.Now()
+	if expected.Now != nil {
+		now = expected.Now()
+	}
+	if claims.NotBefore != nil && now.Add(cksLeeway).Before(claims.NotBefore.Time()) {
+		return nil, errors.New("invalid not before (nbf) claim: token not yet valid")
+	}
+	if claims.Expiry != nil && now.Add(-cksLeeway).After(claims.Expiry.Time()) {
+		return nil, errors.New("invalid expiration time (exp) claim: token is expired")
+	}
+	if claims.IssuedAt != nil && now.Add(cksLeeway).Before(claims.IssuedAt.Time()) {
+		return nil, errors.New("invalid issued at (iat) claim: token issued in the future")
+	}
+
+	return allClaims, nil
+}
+
+// validateSigningAlgorithm checks whether the JWS "alg" (Algorithm) header
+// parameter value for the given JWT matches any given in expectedAlgorithms.
+// If expectedAlgorithms is empty, "RS256" will be expected by default.
+func validateSigningAlgorithm(token string, expectedAlgorithms []string) error {
+	jws, err := jose.ParseSigned(token)
+	if err != nil {
+		return err
+	}
+
+	switch len(jws.Signatures) {
+	case 0:
+		return fmt.Errorf("token must be signed")
+	case 1:
+	default:
+		return fmt.Errorf("token with multiple signatures not supported")
+	}
+
+	if len(expectedAlgorithms) == 0 {
+		expectedAlgorithms = []string{string(jose.RS256)}
+	}
+
+	alg := jws.Signatures[0].Header.Algorithm
+	if !contains(expectedAlgorithms, alg) {
+		return fmt.Errorf("token signed with unexpected algorithm")
+	}
+
+	return nil
+}
+
+// validateAudience checks whether any of the audiences in audClaim match those
+// in expectedAudiences. If there are no expected audiences, then the presence
+// of any audience in audClaim is considered an error.
+func validateAudience(expectedAudiences, audClaim []string) error {
+	if len(expectedAudiences) == 0 && len(audClaim) > 0 {
+		return errors.New("audience claim found in token but expected none")
+	}
+
+	if len(expectedAudiences) > 0 {
+		for _, v := range expectedAudiences {
+			if contains(audClaim, v) {
+				return nil
+			}
+		}
+		return errors.New("audience claim does not match any expected audience")
+	}
+
+	return nil
+}
+
+func contains(sl []string, st string) bool {
+	for _, s := range sl {
+		if s == st {
+			return true
+		}
+	}
+	return false
+}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -205,10 +205,8 @@ func (v *Validator) Validate(ctx context.Context, token string, expected Expecte
 // parameter value for the given JWT matches any given in expectedAlgorithms.
 // If expectedAlgorithms is empty, RS256 will be expected by default.
 func validateSigningAlgorithm(token string, expectedAlgorithms []Alg) error {
-	for _, expected := range expectedAlgorithms {
-		if !supportedAlgorithms[expected] {
-			return fmt.Errorf("unsupported signing algorithm %q", expected)
-		}
+	if err := SupportedSigningAlgorithm(expectedAlgorithms...); err != nil {
+		return err
 	}
 
 	jws, err := jose.ParseSigned(token)

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -11,9 +11,9 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-const (
-	defaultLeewaySeconds = 150
-)
+// DefaultLeewaySeconds defines the amount of leeway that's used by default
+// for validating the "nbf" (Not Before) and "exp" (Expiration Time) claims.
+const DefaultLeewaySeconds = 150
 
 // Validator validates JSON Web Tokens (JWT) by providing signature
 // verification and claims set validation.
@@ -139,7 +139,7 @@ func (v *Validator) Validate(ctx context.Context, token string, expected Expecte
 		if expected.ExpirationLeeway.Seconds() < 0 {
 			leeway = 0
 		} else if expected.ExpirationLeeway.Seconds() == 0 {
-			leeway = defaultLeewaySeconds
+			leeway = DefaultLeewaySeconds
 		}
 		*claims.Expiry = jwt.NumericDate(int64(latestStart) + int64(leeway))
 	}
@@ -154,7 +154,7 @@ func (v *Validator) Validate(ctx context.Context, token string, expected Expecte
 			if expected.NotBeforeLeeway.Seconds() < 0 {
 				leeway = 0
 			} else if expected.NotBeforeLeeway.Seconds() == 0 {
-				leeway = defaultLeewaySeconds
+				leeway = DefaultLeewaySeconds
 			}
 			*claims.NotBefore = jwt.NumericDate(int64(*claims.Expiry) - int64(leeway))
 		}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -47,8 +47,7 @@ type Expected struct {
 
 	// The list of expected JWT "aud" (audience) claim values to match against.
 	// The JWT claim will be considered valid if it matches any of the expected
-	// audiences. If there are no expected audiences, then the presence of any
-	// audience in the JWT will render it invalid.
+	// audiences. If empty, validation is skipped.
 	Audiences []string
 
 	// SigningAlgorithms provides the list of expected JWS "alg" (algorithm) header
@@ -229,24 +228,21 @@ func validateSigningAlgorithm(token string, expectedAlgorithms []string) error {
 	return nil
 }
 
-// validateAudience checks whether any of the audiences in audClaim match those
-// in expectedAudiences. If there are no expected audiences, then the presence
-// of any audience in audClaim is considered an error.
+// validateAudience returns an error if audClaim does not contain any audiences
+// given by expectedAudiences. If expectedAudiences is empty, it skips validation
+// and returns nil.
 func validateAudience(expectedAudiences, audClaim []string) error {
-	if len(expectedAudiences) == 0 && len(audClaim) > 0 {
-		return errors.New("audience claim found in token but expected none")
+	if len(expectedAudiences) == 0 {
+		return nil
 	}
 
-	if len(expectedAudiences) > 0 {
-		for _, v := range expectedAudiences {
-			if contains(audClaim, v) {
-				return nil
-			}
+	for _, v := range expectedAudiences {
+		if contains(audClaim, v) {
+			return nil
 		}
-		return errors.New("audience claim does not match any expected audience")
 	}
 
-	return nil
+	return errors.New("audience claim does not match any expected audience")
 }
 
 func contains(sl []string, st string) bool {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1,0 +1,1 @@
+package jwt

--- a/jwt/keyset.go
+++ b/jwt/keyset.go
@@ -196,10 +196,8 @@ func createCAContext(ctx context.Context, caPEM string) (context.Context, error)
 	}
 
 	tr := cleanhttp.DefaultPooledTransport()
-	if certPool != nil {
-		tr.TLSClientConfig = &tls.Config{
-			RootCAs: certPool,
-		}
+	tr.TLSClientConfig = &tls.Config{
+		RootCAs: certPool,
 	}
 	tc := &http.Client{
 		Transport: tr,

--- a/jwt/keyset.go
+++ b/jwt/keyset.go
@@ -83,13 +83,11 @@ func NewOIDCDiscoveryKeySet(ctx context.Context, issuer string, issuerCAPEM stri
 	}
 
 	// Unmarshal the response body to obtain the issuer and JWKS URL
-	type providerJSON struct {
+	var p struct {
 		Issuer  string `json:"issuer"`
 		JWKSURL string `json:"jwks_uri"`
 	}
-	var p providerJSON
-	err = unmarshalResp(resp, body, &p)
-	if err != nil {
+	if err := unmarshalResp(resp, body, &p); err != nil {
 		return nil, fmt.Errorf("failed to decode OIDC discovery document: %w", err)
 	}
 

--- a/jwt/keyset.go
+++ b/jwt/keyset.go
@@ -1,0 +1,217 @@
+package jwt
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net/http"
+
+	"github.com/coreos/go-oidc"
+	"github.com/hashicorp/go-cleanhttp"
+	"golang.org/x/oauth2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+// KeySet represents a set of keys that can be used to verify the signatures of JWTs.
+// A KeySet is expected to be backed by a set of local or remote keys.
+type KeySet interface {
+
+	// VerifySignature parses the given JWT, verifies its signature, and returns the claims in its payload.
+	VerifySignature(ctx context.Context, token string) (claims map[string]interface{}, err error)
+}
+
+// OIDCDiscoveryKeySet verifies JWT signatures using keys obtained by the OIDC discovery mechanism.
+type OIDCDiscoveryKeySet struct {
+	provider *oidc.Provider
+}
+
+// JSONWebKeySet verifies JWT signatures using keys obtained from a JWKS URL.
+type JSONWebKeySet struct {
+	remoteJWKS oidc.KeySet
+}
+
+// StaticKeySet verifies JWT signatures using local PEM-encoded public keys.
+type StaticKeySet struct {
+	publicKeys []interface{}
+}
+
+// NewOIDCDiscoveryKeySet returns a KeySet that verifies JWT signatures using keys from the
+// JSON Web Key Set (JWKS) published in the discovery document at the given discoveryURL.
+// The client used to obtain the remote keys will verify server certificates using the root
+// certificates provided by discoveryCAPEM.
+func NewOIDCDiscoveryKeySet(ctx context.Context, discoveryURL string, discoveryCAPEM string) (KeySet, error) {
+	if discoveryURL == "" {
+		return nil, errors.New("discoveryURL must not be empty")
+	}
+
+	caCtx, err := createCAContext(ctx, discoveryCAPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := oidc.NewProvider(caCtx, discoveryURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OIDCDiscoveryKeySet{
+		provider: provider,
+	}, nil
+}
+
+// VerifySignature parses the given JWT, verifies its signature using discovered JWKS keys, and
+// returns the claims in its payload. The given JWT must be of the JWS compact serialization form.
+func (ks OIDCDiscoveryKeySet) VerifySignature(ctx context.Context, token string) (map[string]interface{}, error) {
+	// Verify only the signature
+	oidcConfig := &oidc.Config{
+		SkipClientIDCheck: true,
+		SkipExpiryCheck:   true,
+		SkipIssuerCheck:   true,
+	}
+
+	verifier := ks.provider.Verifier(oidcConfig)
+	idToken, err := verifier.Verify(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	allClaims := make(map[string]interface{})
+	if err := idToken.Claims(&allClaims); err != nil {
+		return nil, err
+	}
+
+	return allClaims, nil
+}
+
+// NewJSONWebKeySet returns a KeySet that verifies JWT signatures using keys from the JSON Web
+// Key Set (JWKS) at the given jwksURL. The client used to obtain the remote JWKS will verify
+// server certificates using the root certificates provided by jwksCAPEM.
+func NewJSONWebKeySet(ctx context.Context, jwksURL string, jwksCAPEM string) (KeySet, error) {
+	if jwksURL == "" {
+		return nil, errors.New("jwksURL must not be empty")
+	}
+
+	caCtx, err := createCAContext(ctx, jwksCAPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	return JSONWebKeySet{
+		remoteJWKS: oidc.NewRemoteKeySet(caCtx, jwksURL),
+	}, nil
+}
+
+// VerifySignature parses the given JWT, verifies its signature using JWKS keys, and returns
+// the claims in its payload. The given JWT must be of the JWS compact serialization form.
+func (ks JSONWebKeySet) VerifySignature(ctx context.Context, token string) (map[string]interface{}, error) {
+	payload, err := ks.remoteJWKS.VerifySignature(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal payload into a set of all received claims
+	allClaims := map[string]interface{}{}
+	if err := json.Unmarshal(payload, &allClaims); err != nil {
+		return nil, err
+	}
+
+	return allClaims, nil
+}
+
+// NewStaticKeySet returns a KeySet that verifies JWT signatures using PEM-encoded public keys.
+// The given publicKeys must be of PEM-encoded x509 certificate or PKIX public key forms.
+func NewStaticKeySet(publicKeys []string) (KeySet, error) {
+	parsedPublicKeys := make([]interface{}, 0)
+	for _, k := range publicKeys {
+		key, err := parsePublicKeyPEM([]byte(k))
+		if err != nil {
+			return nil, err
+		}
+		parsedPublicKeys = append(parsedPublicKeys, key)
+	}
+
+	return StaticKeySet{
+		publicKeys: parsedPublicKeys,
+	}, nil
+}
+
+// VerifySignature parses the given JWT, verifies its signature using local PEM-encoded public keys,
+// and returns the claims in its payload. The given JWT must be of the JWS compact serialization form.
+func (ks StaticKeySet) VerifySignature(_ context.Context, token string) (map[string]interface{}, error) {
+	parsedJWT, err := jwt.ParseSigned(token)
+	if err != nil {
+		return nil, err
+	}
+
+	var valid bool
+	allClaims := map[string]interface{}{}
+	for _, key := range ks.publicKeys {
+		if err := parsedJWT.Claims(key, &allClaims); err == nil {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return nil, errors.New("no known key successfully validated the token signature")
+	}
+
+	return allClaims, nil
+}
+
+// parsePublicKeyPEM is used to parse RSA and ECDSA public keys from PEMs.
+// It returns a *rsa.PublicKey or *ecdsa.PublicKey.
+func parsePublicKeyPEM(data []byte) (interface{}, error) {
+	block, data := pem.Decode(data)
+	if block != nil {
+		var rawKey interface{}
+		var err error
+		if rawKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+			if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+				rawKey = cert.PublicKey
+			} else {
+				return nil, err
+			}
+		}
+
+		if rsaPublicKey, ok := rawKey.(*rsa.PublicKey); ok {
+			return rsaPublicKey, nil
+		}
+		if ecPublicKey, ok := rawKey.(*ecdsa.PublicKey); ok {
+			return ecPublicKey, nil
+		}
+	}
+
+	return nil, errors.New("data does not contain any valid RSA or ECDSA public keys")
+}
+
+// createCAContext returns a context with a custom TLS client that's configured with the root
+// certificates from caPEM. If no certificates are configured, the original context is returned.
+func createCAContext(ctx context.Context, caPEM string) (context.Context, error) {
+	if caPEM == "" {
+		return ctx, nil
+	}
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM([]byte(caPEM)); !ok {
+		return nil, errors.New("could not parse CA PEM value successfully")
+	}
+
+	tr := cleanhttp.DefaultPooledTransport()
+	if certPool != nil {
+		tr.TLSClientConfig = &tls.Config{
+			RootCAs: certPool,
+		}
+	}
+	tc := &http.Client{
+		Transport: tr,
+	}
+
+	caCtx := context.WithValue(ctx, oauth2.HTTPClient, tc)
+
+	return caCtx, nil
+}

--- a/jwt/keyset.go
+++ b/jwt/keyset.go
@@ -90,7 +90,7 @@ func NewOIDCDiscoveryKeySet(ctx context.Context, issuer string, issuerCAPEM stri
 	var p providerJSON
 	err = unmarshalResp(resp, body, &p)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode OIDC discovery document: %v", err)
+		return nil, fmt.Errorf("failed to decode OIDC discovery document: %w", err)
 	}
 
 	// Ensure that the returned issuer matches what was given by issuer

--- a/jwt/keyset.go
+++ b/jwt/keyset.go
@@ -43,7 +43,8 @@ type StaticKeySet struct {
 // NewOIDCDiscoveryKeySet returns a KeySet that verifies JWT signatures using keys from the
 // JSON Web Key Set (JWKS) published in the discovery document at the given discoveryURL.
 // The client used to obtain the remote keys will verify server certificates using the root
-// certificates provided by discoveryCAPEM.
+// certificates provided by discoveryCAPEM. If discoveryCAPEM is not provided, system
+// certificates are used.
 func NewOIDCDiscoveryKeySet(ctx context.Context, discoveryURL string, discoveryCAPEM string) (KeySet, error) {
 	if discoveryURL == "" {
 		return nil, errors.New("discoveryURL must not be empty")
@@ -90,7 +91,8 @@ func (ks OIDCDiscoveryKeySet) VerifySignature(ctx context.Context, token string)
 
 // NewJSONWebKeySet returns a KeySet that verifies JWT signatures using keys from the JSON Web
 // Key Set (JWKS) at the given jwksURL. The client used to obtain the remote JWKS will verify
-// server certificates using the root certificates provided by jwksCAPEM.
+// server certificates using the root certificates provided by jwksCAPEM. If jwksCAPEM is not
+// provided, system certificates are used.
 func NewJSONWebKeySet(ctx context.Context, jwksURL string, jwksCAPEM string) (KeySet, error) {
 	if jwksURL == "" {
 		return nil, errors.New("jwksURL must not be empty")

--- a/jwt/keyset_test.go
+++ b/jwt/keyset_test.go
@@ -1,0 +1,1 @@
+package jwt


### PR DESCRIPTION
## Description

This PR adds an initial implementation of the JWT package, which provides signature verification and claims set validation for [JWTs](https://tools.ietf.org/html/rfc7519) of the [JWS](https://tools.ietf.org/html/rfc7519) form.

The code in this package is similar to that in both the [vault-plugin-auth-jwt](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/path_login.go#L47) and [consul](https://github.com/hashicorp/consul-enterprise/blob/master/internal/go-sso/oidcauth/jwt.go#L24) JWT auth implementations.

## Testing

I've integrated and tested the code in this PR in the [common-jwt-lib](https://github.com/hashicorp/vault-plugin-auth-jwt/compare/common-jwt-lib) branch of vault-plugin-auth-jwt.

Tests are intentionally absent from this PR in order to first agree on the API and behavior of the package. I'll be adding tests and additional documentation in a subsequent PR once there is agreement.