### PR TITLE
support for the WithNonce(...) oidc.Request option

### DIFF
--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -163,11 +163,14 @@ func TestProvider_AuthURL(t *testing.T) {
 	   `
 	customState, err := NewID(WithPrefix("custom_"))
 	require.NoError(t, err)
+	customNonce, err := NewID(WithPrefix("custom_"))
+	require.NoError(t, err)
 
 	allOptsRequest, err := NewRequest(
 		1*time.Minute,
 		redirect,
 		WithState(customState),
+		WithNonce(customNonce),
 		WithAudiences("state-override"),
 		WithScopes("email", "profile"),
 		WithDisplay(WAP),

--- a/oidc/request_test.go
+++ b/oidc/request_test.go
@@ -302,3 +302,24 @@ func Test_WithState(t *testing.T) {
 		assert.Equal(opts, testOpts)
 	})
 }
+
+func Test_WithNonce(t *testing.T) {
+	t.Parallel()
+	t.Run("reqOptions", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+		opts := getReqOpts()
+		testOpts := reqDefaults()
+		assert.Equal(opts, testOpts)
+
+		n, err := base62.Random(128)
+		require.NoError(t, err)
+
+		opts = getReqOpts(WithNonce(n))
+		testOpts = reqDefaults()
+
+		testOpts.withNonce = n
+
+		assert.Equal(opts, testOpts)
+	})
+}


### PR DESCRIPTION
Support for the WithNonce(...) option for NewRequest(..) allows devs to specify their own nonce value.  

This new option is required, if the developer wishes to encode all required Request info into a Request's State.  Encoding all a Request's info into its State would remove the requirement of a Request cache/storage from the developer's application.  We already support a WithState(...) option, and the Request's Nonce was the only Request field which the developer could not specify or change. 