### PR TITLE
Add Provider.DiscoveryInfo(...) which retrieves the published IdP configuration info

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -706,11 +706,11 @@ type DiscoveryInfo struct {
 
 	// UILocalesSupported (OPTIONAL, omitempty): Languages and scripts supported
 	// for the user interface
-	UILocalesSupported []string `json:"ui_locales_supported,,omitempty"`
+	UILocalesSupported []string `json:"ui_locales_supported,omitempty"`
 
 	// ClaimsParameterSupported (OPTIONAL, omitempty): Boolean value specifying whether
 	// the OP supports use of the claims parameter, with true indicating support.
-	ClaimsParameterSupported bool `json:"claims_supported"`
+	ClaimsParameterSupported bool `json:"claims_supported,omitempty"`
 
 	// AcrValuesSupported (OPTIONAL, omitempty): a list of the Authentication
 	// Context Class References that this OP supports

--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"mime"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -659,4 +662,114 @@ func (p *Provider) validRedirect(uri string) error {
 		}
 	}
 	return fmt.Errorf("%s: redirect URI %s: %w", op, uri, ErrUnauthorizedRedirectURI)
+}
+
+// DiscoveryInfo is the Provider's configuration info which is published to
+// a well-known discoverable location (based on the Issuer of the provider).
+type DiscoveryInfo struct {
+	// Issuer (REQUIRED): Issuer is a case-sensitive URL string using the https
+	// scheme that contains scheme, host, and optionally, port number and path
+	// components and no query or fragment components.
+	Issuer string `json:"issuer"`
+
+	// AuthURL (REQUIRED): URL of the OP's OAuth 2.0 Authorization Endpoint
+	AuthURL string `json:"authorization_endpoint"`
+
+	// TokenURL (REQUIRED): URL of the OP's OAuth 2.0 Token Endpoint
+	TokenURL string `json:"token_endpoint"`
+
+	// UserInfoURL (OPTIONAL, omitempty): URL of the OP's UserInfo Endpoint
+	UserInfoURL string `json:"userinfo_endpoint,omitempty"`
+
+	// JWKSURL (REQUIRED): URL of the OP's JSON Web Key Set [JWK] document
+	JWKSURL string `json:"jwks_uri"`
+
+	// ScopesSupported (RECOMMENDED, omitempty): scope values that this server
+	// supports.
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+
+	// GrantTypesSupported (OPTIONAL, omitempty):  a list of the OAuth 2.0
+	// Grant Type values that this OP supports. Dynamic OpenID Providers
+	// MUST support the authorization_code and implicit Grant Type values
+	// and MAY support other Grant Types. If omitted, the default value is
+	// ["authorization_code", "implicit"].
+	GrantTypesSupported []string `json:"grant_types_supported,omitempty"`
+
+	// IdTokenSigningAlgsSupported (REQUIRED): a list of the JWS signing
+	// algorithms (alg values) supported by the OP for the ID Token to
+	// encode the Claims in a JWT [JWT]. The algorithm RS256 MUST be included.
+	IdTokenSigningAlgsSupported []string `json:"id_token_signing_alg_values_supported"`
+
+	// DisplayValuesSupported (OPTIONAL, omitempty): a list of the display parameter
+	// values that the OpenID Provider supports.
+	DisplayValuesSupported []string `json:"display_values_supported,omitempty"`
+
+	// UILocalesSupported (OPTIONAL, omitempty): Languages and scripts supported
+	// for the user interface
+	UILocalesSupported []string `json:"ui_locales_supported,,omitempty"`
+
+	// ClaimsParameterSupported (OPTIONAL, omitempty): Boolean value specifying whether
+	// the OP supports use of the claims parameter, with true indicating support.
+	ClaimsParameterSupported bool `json:"claims_supported"`
+
+	// AcrValuesSupported (OPTIONAL, omitempty): a list of the Authentication
+	// Context Class References that this OP supports
+	AcrValuesSupported []string `json:"acr_values_supported,omitempty"`
+}
+
+// DiscoveryInfo will use the provider's Issuer to discover and retrieve its
+// published configuration
+//
+// See: https://openid.net/specs/openid-connect-discovery-1_0.html
+func (p *Provider) DiscoveryInfo(ctx context.Context) (*DiscoveryInfo, error) {
+	const op = "Provider.DiscoveryInfo"
+
+	wellKnown := strings.TrimSuffix(p.config.Issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequest("GET", wellKnown, nil)
+	if err != nil {
+		return nil, err
+	}
+	client, err := p.HTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to read response body: %w", op, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %s", resp.Status, body)
+	}
+
+	var info DiscoveryInfo
+	err = unmarshalRespJSON(resp, body, &info)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to marshal provider discovery information: %w", op, err)
+	}
+
+	if p.config.Issuer != info.Issuer {
+		return nil, fmt.Errorf("%s: provider issuer %s did not match the issuer %s in discovery info by: %w", op, p.config.Issuer, info.Issuer, ErrInvalidIssuer)
+	}
+	return &info, nil
+}
+
+func unmarshalRespJSON(r *http.Response, body []byte, v interface{}) error {
+	const op = "Provider.unmarshalResp"
+	err := json.Unmarshal(body, &v)
+	if err == nil {
+		return nil
+	}
+	ct := r.Header.Get("Content-Type")
+	mediaType, _, parseErr := mime.ParseMediaType(ct)
+	if parseErr == nil && mediaType == "application/json" {
+		return fmt.Errorf("%s: Content-Type = application/json, but could not unmarshal it as JSON: %w", op, err)
+	}
+	return fmt.Errorf("%s: expected Content-Type = application/json, got %q and could not unmarshal it as JSON: %w", op, ct, err)
 }

--- a/oidc/testing_provider_test.go
+++ b/oidc/testing_provider_test.go
@@ -59,6 +59,18 @@ func Test_WithTestPort(t *testing.T) {
 	assert.Equal(opts, testOpts)
 }
 
+func TestTestProvider_SetSupportedScopes(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		tp := StartTestProvider(t)
+		require.Contains(tp.supportedScopes, "openid")
+		tp.SetSupportedScopes("email", "profile")
+		assert.Contains(tp.supportedScopes, "openid")
+		assert.Contains(tp.supportedScopes, "email")
+		assert.Contains(tp.supportedScopes, "profile")
+	})
+}
+
 func TestTestProvider_SetExpectedExpiry(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
@@ -383,7 +395,7 @@ func TestTestProvider_authorize(t *testing.T) {
 		},
 		{
 			name:          "bad-scopes",
-			urlParameters: "&scopes=unknown&state=state-value&response_type=code",
+			urlParameters: "&scope=unknown&state=state-value&response_type=code",
 			want:          "invalid_scope",
 		},
 		{


### PR DESCRIPTION
Adding this capability will allow devs to discover and retrieve the provider's published configuration via the well known location of the JSON document.  Using this published configuration, devs can verify that the provider supports the capabilities they need.