### PR TITLE
Remove erroneous nil

### DIFF
--- a/oidc/testing_provider.go
+++ b/oidc/testing_provider.go
@@ -1474,7 +1474,7 @@ func (p *TestProvider) startCachedCodesCleanupTicking(cancelCtx context.Context)
 			select {
 			case <-cancelCtx.Done():
 				if v, ok := interface{}(p.t).(InfofT); ok {
-					v.Infof("cleanup of cached codes shutting down", nil)
+					v.Infof("cleanup of cached codes shutting down")
 				}
 				return
 			case <-timer.C:


### PR DESCRIPTION
While working on the Boundary TF provider this log line kept bothering me:
```
2021-06-13T07:37:08.771Z [INFO]  dev-oidc: cleanup of cached codes shutting down: EXTRA_VALUE_AT_END=<nil>
```