### PR TITLE
adjust WSL detection

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -15,11 +15,21 @@ func IsWSL() (bool, error) {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		return false, nil
 	}
-	data, err := ioutil.ReadFile("/proc/version")
+	procData, err := ioutil.ReadFile("/proc/version")
 	if err != nil {
 		return false, fmt.Errorf("Unable to read /proc/version: %w", err)
 	}
-	return strings.Contains(strings.ToLower(string(data)), "microsoft"), nil
+
+	cgroupData, err := ioutil.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false, fmt.Errorf("Unable to read /proc/1/cgroup: %w", err)
+	}
+
+	isDocker := strings.Contains(strings.ToLower(string(cgroupData)), "/docker/")
+	isLxc := strings.Contains(strings.ToLower(string(cgroupData)), "/lxc/")
+	isMsLinux := strings.Contains(strings.ToLower(string(procData)), "microsoft")
+	
+	return isMsLinux && !(isDocker || isLxc), nil
 }
 
 // OpenURL opens the specified URL in the default browser of the user. Source:


### PR DESCRIPTION
# Overview
Working within containers as an interactive developer environment (devcontainer) is becoming more prevalent, but improper WSL detection when using OIDC based authentication methods with Vault and Boundary makes using these command line tools problematic in such an environment.

The current method for detecting WSL is to examine /proc/version, looking for the presence of the string "microsoft". However, since Microsoft also uses their linux kernels as the basis of their published devcontainer images/layers, this causes the isWSL() function to return true within that environment as well. When openURL() is subsequently called in order to launch a browser and complete authentication, vault and boundary will opt to try and launch cmd.exe, thinking the environment is WSL, which then fails.

This PR is a proposal for one way to disambiguate this situation, resulting in the auth processes properly calling xdg-open instead of cmd.exe when run in a linux container.

# Design of Change
When detecting WSL, compare both the output of /proc/version as well as the root of the hierarchies in /proc/1/cgroup to determine if we are running within Docker or LCX. Assert that we are WSL only if we detect a microsoft linux kernel and are also not running from within a container.

I am not an expert in runtime detection of containerization. It's possible there may be better ways to detect that scenario.

# Related PR/Issues
Made the same proposal, for the same reasons, in the vault jwt auth plugin here: https://github.com/hashicorp/vault-plugin-auth-jwt/pull/209