### PR TITLE
CI: ensure that all build/test failures are properly detected

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.19
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -24,13 +24,27 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
 
     - name: Build
-      run: find . -name go.mod -execdir go build ./... \;
+      run: |
+        set -e
+        exit_status=
+        for f in $(find . -name go.mod)
+        do
+          pushd $(dirname $f) > /dev/null
+          go build ./... || exit_status=$?
+          popd > /dev/null
+        done
+        exit $status
 
     - name: Test
-      run: find . -name go.mod -execdir go test ./... \;
+      run: |
+        set -e
+        exit_status=
+        for f in $(find . -name go.mod)
+        do
+          pushd $(dirname $f) > /dev/null
+          go test -test.v ./... || exit_status=$?
+          popd > /dev/null
+        done
+        exit $exit_status

--- a/ldap/client_test.go
+++ b/ldap/client_test.go
@@ -296,9 +296,8 @@ func TestClient_connect(t *testing.T) {
 			Name:  "test-logger",
 			Level: hclog.Error,
 		})
-		ln, err := net.Listen("tcp", ":"+"389")
-		ln.Close()
-		if err == nil {
+		if ln, err := net.Listen("tcp", ":"+"389"); err == nil {
+			ln.Close()
 			_ = testdirectory.Start(t, testdirectory.WithNoTLS(t), testdirectory.WithLogger(t, logger), testdirectory.WithPort(t, 389))
 			c, err := NewClient(testCtx, &ClientConfig{
 				URLs: []string{"ldap://127.0.0.1"},
@@ -307,6 +306,8 @@ func TestClient_connect(t *testing.T) {
 			err = c.connect(testCtx)
 			defer func() { c.Close(testCtx) }()
 			assert.NoError(err)
+		} else {
+			t.Logf("warning: failed to listen on port 389, err=%s", err)
 		}
 	})
 }


### PR DESCRIPTION
Previously, no build/test failures would result in a non-zero exit status. This PR should now fail the build/tests steps whenever an error is encountered.

Here's an example of the issue:
https://github.com/hashicorp/cap/actions/runs/3989282340/jobs/6841516383#step:6:10

Other fixes/updates:
- enable verbose testing. (open to dropping this, if it is not desired)
- fix panic in `TestClient_connect`
- bump the min go version to 1.19
- drop support for dep
