### PR TITLE
Fixes overflow in auth_time claim validation on 32bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 Canonical reference for changes, improvements, and bugfixes for cap.
 
+## 0.3.1
+
+### Bug Fixes
+* Fixes integer overflow in `auth_time` claim validation when compiled for 32-bit 
+  architecture ([**PR**](https://github.com/hashicorp/cap/pull/76))
+
 ## 0.3.0
 #### OIDC
 * Add `ProviderConfig` which creates a provider that doesn't support
   OIDC discovery. It's probably better to use NewProvider(...) with discovery
-  whenever possible ([PR](https://github.com/hashicorp/cap/pull/57) and [issue](https://github.com/hashicorp/cap/issues/55)).
+  whenever possible ([**PR**](https://github.com/hashicorp/cap/pull/57) and [issue](https://github.com/hashicorp/cap/issues/55)).
 * Improve WSL detection ([**PR**](https://github.com/hashicorp/cap/pull/51))
 * Add option to allow all of IAT, NBF, and EXP to be missing
   ([**PR**](https://github.com/hashicorp/cap/pull/50))

--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -556,7 +556,7 @@ func (p *Provider) VerifyIDToken(ctx context.Context, t IDToken, oidcRequest Req
 		}
 		authTime := time.Unix(int64(atClaim), 0)
 		if !authTime.Add(leeway).After(authAfter) {
-			return nil, fmt.Errorf("%s: issued at (%s) is beyond max age (%d / %s): %w", op, authTime, secs, authAfter, ErrExpiredAuthTime)
+			return nil, fmt.Errorf("%s: auth_time (%s) is beyond max age (%d / %s): %w", op, authTime, secs, authAfter, ErrExpiredAuthTime)
 		}
 	}
 

--- a/oidc/request.go
+++ b/oidc/request.go
@@ -207,19 +207,20 @@ type Req struct {
 var _ Request = (*Req)(nil)
 
 // NewRequest creates a new Request (*Req).
-//  Supports the options:
-//   * WithState
-//   * WithNonce
-//   * WithNow
-//   * WithAudiences
-//   * WithScopes
-//   * WithImplicit
-//   * WithPKCE
-//   * WithMaxAge
-//   * WithPrompts
-//   * WithDisplay
-//   * WithUILocales
-//   * WithClaims
+//
+//	Supports the options:
+//	 * WithState
+//	 * WithNonce
+//	 * WithNow
+//	 * WithAudiences
+//	 * WithScopes
+//	 * WithImplicit
+//	 * WithPKCE
+//	 * WithMaxAge
+//	 * WithPrompts
+//	 * WithDisplay
+//	 * WithUILocales
+//	 * WithClaims
 func NewRequest(expireIn time.Duration, redirectURL string, opt ...Option) (*Req, error) {
 	const op = "oidc.NewRequest"
 	opts := getReqOpts(opt...)
@@ -274,7 +275,7 @@ func NewRequest(expireIn time.Duration, redirectURL string, opt ...Option) (*Req
 	}
 	r.expiration = r.now().Add(expireIn)
 	if opts.withMaxAge != nil {
-		opts.withMaxAge.authAfter = r.now().Add(time.Duration(-opts.withMaxAge.seconds) * time.Second)
+		opts.withMaxAge.authAfter = r.now().Add(-1 * time.Duration(opts.withMaxAge.seconds) * time.Second)
 		r.withMaxAge = opts.withMaxAge
 	}
 	return r, nil
@@ -630,7 +631,6 @@ func WithACRValues(values ...string) Option {
 // Neither a max or min length is enforced when you use the WithState option.
 //
 // Option is valid for: Request
-//
 func WithState(s string) Option {
 	return func(o interface{}) {
 		if o, ok := o.(*reqOptions); ok {
@@ -663,7 +663,6 @@ func WithState(s string) Option {
 // Neither a max or min length is enforced when you use the WithNonce option.
 //
 // Option is valid for: Request
-//
 func WithNonce(n string) Option {
 	return func(o interface{}) {
 		if o, ok := o.(*reqOptions); ok {


### PR DESCRIPTION
This PR fixes an integer overflow that occurred within `auth_time` claim validation when compiled for 32bit. This was surfaced in Vault's [32bit tests](https://github.com/hashicorp/vault-enterprise/actions/runs/5179545255/jobs/9332600305#step:10:869) where we use `cap/oidc` as a client to Vault's OIDC provider (see [oidc_provider_test.go#L272](https://github.com/hashicorp/vault/blob/main/vault/external_tests/identity/oidc_provider_test.go#L272))

The overflow occurred by directly negating the [`maxAge.seconds`](https://github.com/hashicorp/cap/blob/main/oidc/request.go#L425) which is a `uint`. This caused the `opts.withMaxAge.authAfter` duration to be way in the future. I added additional error logs in the Vault tests to show the value of the duration before and after changes in this PR.

Before:
```
Provider.Exchange: id_token failed verification: ... dur=1193046h22m16s ...
```

After (with expected duration):
```
Provider.Exchange: id_token failed verification: ... dur=-6m0s ...
```