### PR TITLE
Address a set of LDAP issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # cap CHANGELOG
 
 Canonical reference for changes, improvements, and bugfixes for cap.
+## 0.3.2
+
+### Bug fixes:
+* Address a set of LDAP issues ([**PR**](https://github.com/hashicorp/cap/pull/77)):
+  * Properly escape user filters when using UPN domains
+  * Increase max tls to 1.3
+  * Improve `EscapeValue(...)`
+  * Use text template for rendering filters
 
 ## 0.3.1
 

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -10,11 +10,11 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"fmt"
-	"html/template"
 	"math"
 	"net"
 	"net/url"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -830,10 +830,14 @@ func EscapeValue(input string) string {
 	// - trailing space
 	// - special characters '"', '+', ',', ';', '<', '>', '\\'
 	// - null
-	for i := 0; i < len(input); i++ {
+	inputLen := len(input)
+	for i := 0; i < inputLen; i++ {
 		escaped := false
 		if input[i] == '\\' {
 			i++
+			if i > inputLen-1 {
+				break
+			}
 			escaped = true
 		}
 		switch input[i] {
@@ -842,6 +846,9 @@ func EscapeValue(input string) string {
 				input = input[0:i] + "\\" + input[i:]
 				i++
 			}
+			continue
+		case '\000':
+			input = input[0:i] + `\00` + input[i+1:]
 			continue
 		}
 		if escaped {

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -753,7 +753,11 @@ func (c *Client) renderUserSearchFilter(username string) (string, error) {
 	}
 	if c.conf.UPNDomain != "" {
 		context.UserAttr = "userPrincipalName"
-		context.Username = fmt.Sprintf("%s@%s", EscapeValue(username), c.conf.UPNDomain)
+		// Intentionally, calling EscapeFilter(...) (vs EscapeValue) since the
+		// username is being injected into a search filter.
+		// As an untrusted string, the username must be escaped according to RFC
+		// 4515, in order to prevent attackers from injecting characters that could modify the filter
+		context.Username = fmt.Sprintf("%s@%s", EscapeFilter(username), c.conf.UPNDomain)
 	}
 
 	var renderedFilter bytes.Buffer

--- a/ldap/client_test.go
+++ b/ldap/client_test.go
@@ -131,6 +131,12 @@ func TestClient_NewClient(t *testing.T) {
 			wantErrContains: "invalid 'tls_min_version' in config",
 		},
 		{
+			name: "valid-tls-max",
+			conf: &ClientConfig{
+				TLSMaxVersion: "tls13",
+			},
+		},
+		{
 			name: "invalid-tls-max",
 			conf: &ClientConfig{
 				TLSMaxVersion: "invalid-tls-version",

--- a/ldap/config.go
+++ b/ldap/config.go
@@ -35,7 +35,7 @@ const (
 	DefaultTLSMinVersion = "tls12"
 
 	// DefaultTLSMaxVersion for the ClientConfig.TLSMaxVersion
-	DefaultTLSMaxVersion = "tls12"
+	DefaultTLSMaxVersion = "tls13"
 
 	// DefaultOpenLDAPUserPasswordAttribute defines the attribute name for the
 	// openLDAP default password attribute which will always be excluded

--- a/ldap/conn_test.go
+++ b/ldap/conn_test.go
@@ -13,12 +13,16 @@ func Test_EscapeValue(t *testing.T) {
 		"test\\hello": "test\\\\hello",
 		"  test  ":    "\\  test \\ ",
 		"":            "",
+		`\`:           `\`,
+		"golang\000":  `golang\00`,
+		"go\000lang":  `go\00lang`,
+		"\000":        `\00`,
 	}
 
 	for test, answer := range testcases {
 		res := EscapeValue(test)
 		if res != answer {
-			t.Errorf("Failed to escape %s: %s != %s\n", test, res, answer)
+			t.Errorf("Failed to escape %q: %q != %q\n", test, res, answer)
 		}
 	}
 }


### PR DESCRIPTION
- [fix (ldap): properly escape user filters with UPN domains](https://github.com/hashicorp/cap/commit/1d638ddf393c33b674f2b4f9b249a7013cab604b)
- [fix (ldap): increase max tls to 1.3](https://github.com/hashicorp/cap/commit/822334cca7e6209d4ed206cb36f528da2e9926cb)
- [fix (ldap): improve EscapeValue(...)](https://github.com/hashicorp/cap/commit/dadacf7ea25e01ca7e52f07d3c444bd562d513d9)
- [fix (ldap): use text template for rendering filters](https://github.com/hashicorp/cap/commit/f30bbc56e5cea51d581987bcfc37a5af3d982b3a)