### PR TITLE
Adds ability to provide IdP metadata as XML or individual parameters

### DIFF
--- a/saml/authn_request.go
+++ b/saml/authn_request.go
@@ -143,12 +143,12 @@ func (sp *ServiceProvider) CreateAuthnRequest(
 	// "The message SHOULD contain an AssertionConsumerServiceURL attribute and MUST NOT contain an
 	// AssertionConsumerServiceIndex attribute (i.e., the desired endpoint MUST be the default,
 	// or identified via the AssertionConsumerServiceURL attribute)."
-	ar.AssertionConsumerServiceURL = sp.cfg.AssertionConsumerServiceURL.String()
+	ar.AssertionConsumerServiceURL = sp.cfg.AssertionConsumerServiceURL
 	ar.IssueInstant = time.Now().UTC()
 	ar.Destination = destination
 
 	ar.Issuer = &core.Issuer{}
-	ar.Issuer.Value = sp.cfg.EntityID.String()
+	ar.Issuer.Value = sp.cfg.EntityID
 
 	// [INT_SAML][SDP-SP04]
 	// "The <samlp:AuthnRequest> message MUST either omit the <samlp:NameIDPolicy> element (RECOMMENDED),

--- a/saml/authn_request_test.go
+++ b/saml/authn_request_test.go
@@ -2,7 +2,6 @@ package saml_test
 
 import (
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,24 +17,10 @@ func Test_CreateAuthnRequest(t *testing.T) {
 	tp := testprovider.StartTestProvider(t)
 	defer tp.Close()
 
-	entityID, err := url.Parse("http://test.me/entity")
-	r.NoError(err)
-
-	acs, err := url.Parse("http://test.me/saml/acs")
-	r.NoError(err)
-
-	issuer, err := url.Parse("http://test.idp")
-	r.NoError(err)
-
-	metaURL := fmt.Sprintf("%s/saml/metadata", tp.ServerURL())
-	metadata, err := url.Parse(metaURL)
-	r.NoError(err)
-
 	cfg, err := saml.NewConfig(
-		entityID,
-		acs,
-		issuer,
-		metadata,
+		"http://test.me/entity",
+		"http://test.me/saml/acs",
+		fmt.Sprintf("%s/saml/metadata", tp.ServerURL()),
 	)
 
 	provider, err := saml.NewServiceProvider(cfg)
@@ -116,24 +101,10 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 	tp := testprovider.StartTestProvider(t)
 	defer tp.Close()
 
-	entityID, err := url.Parse("http://test.me/entity")
-	r.NoError(err)
-
-	acs, err := url.Parse("http://test.me/saml/acs")
-	r.NoError(err)
-
-	issuer, err := url.Parse("http://test.idp")
-	r.NoError(err)
-
-	metaURL := fmt.Sprintf("%s/saml/metadata", tp.ServerURL())
-	metadata, err := url.Parse(metaURL)
-	r.NoError(err)
-
 	cfg, err := saml.NewConfig(
-		entityID,
-		acs,
-		issuer,
-		metadata,
+		"http://test.me/entity",
+		"http://test.me/saml/acs",
+		fmt.Sprintf("%s/saml/metadata", tp.ServerURL()),
 	)
 
 	provider, err := saml.NewServiceProvider(cfg)

--- a/saml/config.go
+++ b/saml/config.go
@@ -67,14 +67,14 @@ func (c *MetadataParameters) Validate() error {
 		return fmt.Errorf("issuer not set")
 	}
 	if _, err := url.Parse(c.Issuer); err != nil {
-		return fmt.Errorf("failed to parse Issuer: %w", err)
+		return fmt.Errorf("provided Issuer is not a valid URL: %w", err)
 	}
 
 	if c.SingleSignOnURL == "" {
 		return fmt.Errorf("SSO URL not set")
 	}
 	if _, err := url.Parse(c.SingleSignOnURL); err != nil {
-		return fmt.Errorf("failed to parse SSO URL: %w", err)
+		return fmt.Errorf("provided SSO URL is not a valid URL: %w", err)
 	}
 
 	if _, err := parsePEMCertificate([]byte(c.IDPCertificate)); err != nil {
@@ -166,14 +166,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("%s: ACS URL not set: %w", op, ErrInvalidParameter)
 	}
 	if _, err := url.Parse(c.AssertionConsumerServiceURL); err != nil {
-		return fmt.Errorf("%s: failed to parse ACS URL: %w", op, ErrInvalidParameter)
+		return fmt.Errorf("%s: provided ACS URL is not a valid URL: %w", op, ErrInvalidParameter)
 	}
 
 	if c.EntityID == "" {
 		return fmt.Errorf("%s: EntityID not set: %w", op, ErrInvalidParameter)
 	}
 	if _, err := url.Parse(c.EntityID); err != nil {
-		return fmt.Errorf("%s: failed to parse EntityID: %w", op, ErrInvalidParameter)
+		return fmt.Errorf("%s: provided Entity ID is not a valid URL: %w", op, ErrInvalidParameter)
 	}
 
 	if c.MetadataURL == "" && c.MetadataXML == "" && c.MetadataParameters == nil {
@@ -182,7 +182,7 @@ func (c *Config) Validate() error {
 	}
 	if c.MetadataURL != "" {
 		if _, err := url.Parse(c.MetadataURL); err != nil {
-			return fmt.Errorf("%s: failed to parse MetadataURL: %w", op, ErrInvalidParameter)
+			return fmt.Errorf("%s: provided Metadata URL is not a valid URL: %w", op, ErrInvalidParameter)
 		}
 	}
 	if c.MetadataXML != "" {

--- a/saml/config.go
+++ b/saml/config.go
@@ -199,7 +199,7 @@ func (c *Config) Validate() error {
 
 	if c.GenerateAuthRequestID == nil {
 		return fmt.Errorf(
-			"%s: DefaultGenerateAuthRequestID func not provided: %w",
+			"%s: GenerateAuthRequestID func not provided: %w",
 			op,
 			ErrInvalidParameter,
 		)

--- a/saml/config.go
+++ b/saml/config.go
@@ -1,55 +1,153 @@
 package saml
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"time"
 
-	"github.com/hashicorp/cap/oidc"
+	"github.com/hashicorp/cap/saml/models/core"
 	"github.com/hashicorp/go-uuid"
 )
-
-var ErrInvalidTLSCert = errors.New("invalid tls certificate")
 
 type ValidUntilFunc func() time.Time
 
 type GenerateAuthRequestIDFunc func() (string, error)
 
 type Config struct {
-	// AssertionConsumerServiceURL defines the endpoint at the SP where the IDP
-	// will redirect to with its authentication response. (required)
-	AssertionConsumerServiceURL *url.URL
+	// AssertionConsumerServiceURL defines the endpoint at the service provider where
+	// the identity provider will redirect to with its authentication response. Must be
+	// a valid URL. Required.
+	AssertionConsumerServiceURL string
 
-	// EntityID is a globaly unique identifier of the service provider. (required)
-	EntityID *url.URL
+	// EntityID is a globally unique identifier of the service provider. Must be a
+	// valid URL. Required.
+	EntityID string
 
-	// Issuer is a globaly unique identifier of the identity provider. (required)
-	Issuer *url.URL
+	// MetadataURL is the endpoint an identity provider serves its metadata XML document.
+	// Must be a valid URL. Takes precedence over MetadataXML and MetadataParameters.
+	// Required if MetadataXML or MetadataParameters not set.
+	MetadataURL string
 
-	// MetadataURL is the endpoint an IDP serves its metadata XML document. (required)
-	MetadataURL *url.URL
+	// MetadataXML is the XML-formatted metadata an identity provider provides to
+	// configure a service provider. Takes precedence over MetadataParameters. Optional.
+	MetadataXML string
 
-	// ValidUntil is a function that defines until the generated service provider metadata
-	// document is valid.
+	// MetadataParameters are the individual parameters an identity provider provides
+	// to configure a service provider. Optional.
+	MetadataParameters *MetadataParameters
+
+	// ValidUntil is a function that defines the time after which the service provider
+	// metadata document is considered invalid. Optional.
 	ValidUntil ValidUntilFunc
 
-	// GenerateAuthRequestID generates a XSD:ID conform ID.
+	// GenerateAuthRequestID generates an XSD:ID conforming ID.
 	GenerateAuthRequestID GenerateAuthRequestIDFunc
 }
 
-// NewConfig creates a new SAML Config.
-func NewConfig(entityID, acs, issuer, metadata *url.URL) (*Config, error) {
+type MetadataParameters struct {
+	// Issuer is a globally unique identifier of the identity provider.
+	// Must be a valid URL. Required.
+	Issuer string
+
+	// SingleSignOnURL is the single sign-on service URL of the identity provider.
+	// Must be a valid URL. Required.
+	SingleSignOnURL string
+
+	// IDPCertificate is the PEM-encoded public key certificate provided by the identity
+	// provider. Used to verify response and assertion signatures. Required.
+	IDPCertificate string
+
+	// Binding defines the binding that will be used for authentication requests. Defaults
+	// to HTTP-POST binding. Optional.
+	Binding core.ServiceBinding
+}
+
+func (c *MetadataParameters) Validate() error {
+	if c.Issuer == "" {
+		return fmt.Errorf("issuer not set")
+	}
+	if _, err := url.Parse(c.Issuer); err != nil {
+		return fmt.Errorf("failed to parse Issuer: %w", err)
+	}
+
+	if c.SingleSignOnURL == "" {
+		return fmt.Errorf("SSO URL not set")
+	}
+	if _, err := url.Parse(c.SingleSignOnURL); err != nil {
+		return fmt.Errorf("failed to parse SSO URL: %w", err)
+	}
+
+	if _, err := parsePEMCertificate([]byte(c.IDPCertificate)); err != nil {
+		return fmt.Errorf("failed to parse IDP certificate: %w", err)
+	}
+
+	return nil
+}
+
+// WithMetadataXML provides optional identity provider metadata in the form of an XML
+// document that can be used to configure the service provider.
+func WithMetadataXML(metadata string) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*configOptions); ok {
+			o.withMetadataXML = metadata
+		}
+	}
+}
+
+// WithMetadataParameters provides optional static metadata from an identity provider
+// that can be used to configure the service provider.
+func WithMetadataParameters(metadata MetadataParameters) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*configOptions); ok {
+			if metadata.Binding == "" {
+				metadata.Binding = core.ServiceBindingHTTPPost
+			}
+			o.withMetadataParameters = &metadata
+		}
+	}
+}
+
+// WithValidUntil provides the time after which the service provider metadata
+// document is considered invalid
+func WithValidUntil(validUntil ValidUntilFunc) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*configOptions); ok {
+			o.withValidUntil = validUntil
+		}
+	}
+}
+
+// WithGenerateAuthRequestID provides an XSD:ID conforming ID for authentication requests
+func WithGenerateAuthRequestID(generateAuthRequestID GenerateAuthRequestIDFunc) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*configOptions); ok {
+			o.withGenerateAuthRequestID = generateAuthRequestID
+		}
+	}
+}
+
+// NewConfig creates a new configuration for a service provider. Identity provider
+// metadata can be provided via the metadataURL parameter or the WithMetadataXML
+// and WithMetadataParameters options. The metadataURL will always take precedence
+// if options are provided.
+//
+// Options:
+// - WithValidUntil
+// - WithMetadataXML
+// - WithMetadataParameters
+func NewConfig(entityID, acs, metadataURL string, opt ...Option) (*Config, error) {
 	const op = "saml.NewConfig"
+
+	opts := getConfigOptions(opt...)
 
 	cfg := &Config{
 		EntityID:                    entityID,
-		Issuer:                      issuer,
 		AssertionConsumerServiceURL: acs,
-		MetadataURL:                 metadata,
-
-		ValidUntil:            DefaultValidUntil,
-		GenerateAuthRequestID: GenerateAuthRequestID,
+		MetadataURL:                 metadataURL,
+		MetadataXML:                 opts.withMetadataXML,
+		MetadataParameters:          opts.withMetadataParameters,
+		ValidUntil:                  opts.withValidUntil,
+		GenerateAuthRequestID:       opts.withGenerateAuthRequestID,
 	}
 
 	err := cfg.Validate()
@@ -60,9 +158,87 @@ func NewConfig(entityID, acs, issuer, metadata *url.URL) (*Config, error) {
 	return cfg, nil
 }
 
-// GenerateAuthRequestID generates an auth XSD:ID conform ID.
+// Validate validates the provided configuration.
+func (c *Config) Validate() error {
+	const op = "saml.Config.Validate"
+
+	if c.AssertionConsumerServiceURL == "" {
+		return fmt.Errorf("%s: ACS URL not set: %w", op, ErrInvalidParameter)
+	}
+	if _, err := url.Parse(c.AssertionConsumerServiceURL); err != nil {
+		return fmt.Errorf("%s: failed to parse ACS URL: %w", op, ErrInvalidParameter)
+	}
+
+	if c.EntityID == "" {
+		return fmt.Errorf("%s: EntityID not set: %w", op, ErrInvalidParameter)
+	}
+	if _, err := url.Parse(c.EntityID); err != nil {
+		return fmt.Errorf("%s: failed to parse EntityID: %w", op, ErrInvalidParameter)
+	}
+
+	if c.MetadataURL == "" && c.MetadataXML == "" && c.MetadataParameters == nil {
+		return fmt.Errorf("%s: One of MetadataURL, MetadataXML, or MetadataParameters "+
+			"must be set: %w", op, ErrInvalidParameter)
+	}
+	if c.MetadataURL != "" {
+		if _, err := url.Parse(c.MetadataURL); err != nil {
+			return fmt.Errorf("%s: failed to parse MetadataURL: %w", op, ErrInvalidParameter)
+		}
+	}
+	if c.MetadataXML != "" {
+		if _, err := parseIDPMetadata([]byte(c.MetadataXML)); err != nil {
+			return fmt.Errorf("%s: %s: %w", op, err.Error(), ErrInvalidParameter)
+		}
+	}
+
+	if c.MetadataParameters != nil {
+		if err := c.MetadataParameters.Validate(); err != nil {
+			return fmt.Errorf("%s: %s: %w", op, err.Error(), ErrInvalidParameter)
+		}
+	}
+
+	if c.GenerateAuthRequestID == nil {
+		return fmt.Errorf(
+			"%s: DefaultGenerateAuthRequestID func not provided: %w",
+			op,
+			ErrInvalidParameter,
+		)
+	}
+
+	return nil
+}
+
+type configOptions struct {
+	withMetadataXML           string
+	withMetadataParameters    *MetadataParameters
+	withValidUntil            ValidUntilFunc
+	withGenerateAuthRequestID GenerateAuthRequestIDFunc
+}
+
+func configOptionsDefault() configOptions {
+	return configOptions{
+		withValidUntil: DefaultValidUntil,
+	}
+}
+
+func getConfigOptions(opt ...Option) configOptions {
+	opts := configOptionsDefault()
+	ApplyOpts(&opts, opt...)
+
+	// Apply defaults to options
+	if opts.withGenerateAuthRequestID == nil {
+		opts.withGenerateAuthRequestID = DefaultGenerateAuthRequestID
+	}
+	if opts.withValidUntil == nil {
+		opts.withValidUntil = DefaultValidUntil
+	}
+
+	return opts
+}
+
+// DefaultGenerateAuthRequestID generates an auth XSD:ID conform ID.
 // A UUID prefixed with an underscore.
-func GenerateAuthRequestID() (string, error) {
+func DefaultGenerateAuthRequestID() (string, error) {
 	newID, err := uuid.GenerateUUID()
 	if err != nil {
 		return "", err
@@ -73,42 +249,6 @@ func GenerateAuthRequestID() (string, error) {
 	return fmt.Sprintf("_%s", newID), nil
 }
 
-// Validate validates the provided configuration.
-func (c *Config) Validate() error {
-	const op = "saml.Config.Validate"
-
-	if c.AssertionConsumerServiceURL == nil {
-		return fmt.Errorf("%s: ACS URL not set: %w", op, oidc.ErrInvalidParameter)
-	}
-
-	if c.EntityID == nil {
-		return fmt.Errorf("%s: EntityID not set: %w", op, oidc.ErrInvalidParameter)
-	}
-
-	if c.Issuer == nil {
-		return fmt.Errorf("%s: Issuer not set: %w", op, oidc.ErrInvalidParameter)
-	}
-
-	if c.MetadataURL == nil {
-		return fmt.Errorf("%s: Metadata URL not set: %w", op, oidc.ErrInvalidParameter)
-	}
-
-	if c.ValidUntil == nil {
-		return fmt.Errorf("%s: ValidUntil func not provided: %w", op, oidc.ErrInvalidParameter)
-	}
-
-	if c.GenerateAuthRequestID == nil {
-		return fmt.Errorf(
-			"%s: GenerateAuthRequestID func not provided: %w",
-			op,
-			oidc.ErrInvalidParameter,
-		)
-	}
-
-	return nil
-}
-
-// DefaultValidUntil
 func DefaultValidUntil() time.Time {
 	return time.Now().Add(time.Hour * 24 * 365)
 }

--- a/saml/error.go
+++ b/saml/error.go
@@ -1,0 +1,9 @@
+package saml
+
+import "errors"
+
+var (
+	ErrInvalidParameter   = errors.New("invalid parameter")
+	ErrBindingUnsupported = errors.New("configured binding unsupported by the IDP")
+	ErrInvalidTLSCert     = errors.New("invalid tls certificate")
+)

--- a/saml/internal/test/context.go
+++ b/saml/internal/test/context.go
@@ -1,0 +1,1 @@
+package context

--- a/saml/models/metadata/common.go
+++ b/saml/models/metadata/common.go
@@ -8,8 +8,8 @@ import "github.com/hashicorp/cap/saml/models/core"
   See 2.2 Common Types - http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf
 */
 
-//EndpointType describes a SAML protocol binding endpoint at which a SAML entity can
-//be sent protocol messages.
+// EndpointType describes a SAML protocol binding endpoint at which a SAML entity can
+// be sent protocol messages.
 // See 2.2.2 http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf
 type Endpoint struct {
 	Binding          core.ServiceBinding `xml:",attr"`

--- a/saml/models/metadata/entity_descriptor.go
+++ b/saml/models/metadata/entity_descriptor.go
@@ -55,9 +55,9 @@ type EntitiesDescriptor struct {
 	EntityDescriptor   []*EntityDescriptor
 }
 
-// entityDescriptor represents a system entity (IdP or SP) in metadata.
+// EntityDescriptor represents a system entity (IdP or SP) in metadata.
 // See 2.3.2 in http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf
-type entityDescriptor struct {
+type EntityDescriptor struct {
 	DescriptorCommon
 
 	EntityID string `xml:"entityID,attr"`
@@ -66,25 +66,6 @@ type entityDescriptor struct {
 	Organization               *Organization
 	ContactPerson              *ContactPerson
 	AdditionalMetadataLocation []string
-}
-
-// EntityDescriptorComplete represents a system entity (IdP or SP) in metadata.
-// See 2.3.2 in http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf
-type EntityDescriptor struct {
-	DescriptorCommon
-
-	EntityID string
-
-	RoleDescriptor               []*RoleDescriptor
-	IDPSSODescriptor             []*IDPSSODescriptor
-	SPSSODescriptor              []*SPSSODescriptor
-	AuthnAuthorityDescriptor     []*AuthnAuthorityDescriptor
-	AttributeAuthorityDescriptor []*AttributeAuthorityDescriptor
-	PDPDescriptor                []*PDPDescriptor
-	AffiliationDescriptor        *AffiliationDescriptor
-	Organization                 *Organization
-	ContactPerson                *ContactPerson
-	AdditionalMetadataLocation   []string
 }
 
 // Organization specifies basic information about an organization responsible for a SAML
@@ -183,42 +164,6 @@ type AttributeAuthorityDescriptor struct {
 // entitites, such as related service providers that
 // share a persistent NameID.
 type AffiliationDescriptor struct {
-}
-
-func (e *EntityDescriptor) GetSSOBindingLocation(binding core.ServiceBinding) string {
-	for _, idpSSODescriptor := range e.IDPSSODescriptor {
-		for _, ssoSvc := range idpSSODescriptor.SingleSignOnService {
-			if ssoSvc.Binding == binding {
-				return ssoSvc.Location
-			}
-		}
-	}
-
-	return ""
-}
-
-func (e *EntityDescriptor) GetSLOBindingLocation(binding core.ServiceBinding) string {
-	for _, idpSSODescriptor := range e.IDPSSODescriptor {
-		for _, sloSvc := range idpSSODescriptor.SingleLogoutService {
-			if sloSvc.Binding == binding {
-				return sloSvc.Location
-			}
-		}
-	}
-
-	return ""
-}
-
-func (e *EntityDescriptor) GetArtifactBindingLocation(binding core.ServiceBinding) string {
-	for _, idpSSODescriptor := range e.IDPSSODescriptor {
-		for _, arSvc := range idpSSODescriptor.ArtifactResolutionService {
-			if arSvc.Binding == binding {
-				return arSvc.Location
-			}
-		}
-	}
-
-	return ""
 }
 
 // X509Data contains one ore more identifiers of keys or X509 certifactes.

--- a/saml/models/metadata/idp_sso_descriptor.go
+++ b/saml/models/metadata/idp_sso_descriptor.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/cap/saml/models/core"
 )
 
-// IDPSSODescriptor contains profiles specfic to identity providers supporting SSO.
+// IDPSSODescriptor contains profiles specific to identity providers supporting SSO.
 // It extends the SSODescriptor type.
 // See 2.4.3 http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf
 type IDPSSODescriptor struct {
@@ -25,7 +25,7 @@ type IDPSSODescriptor struct {
 // EntityDescriptorIDPSSO is an EntityDescriptor that accommodates the IDPSSODescriptor
 // as descriptor field only.
 type EntityDescriptorIDPSSO struct {
-	entityDescriptor
+	EntityDescriptor
 
 	IDPSSODescriptor []*IDPSSODescriptor
 }

--- a/saml/models/metadata/sp_sso_descriptor.go
+++ b/saml/models/metadata/sp_sso_descriptor.go
@@ -8,7 +8,7 @@ import "encoding/xml"
 type EntityDescriptorSPSSO struct {
 	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:metadata EntityDescriptor"`
 
-	entityDescriptor
+	EntityDescriptor
 
 	SPSSODescriptor []*SPSSODescriptor
 }

--- a/saml/sp_test.go
+++ b/saml/sp_test.go
@@ -17,15 +17,14 @@ import (
 
 func Test_NewServiceProvider(t *testing.T) {
 	r := require.New(t)
-	exampleURL, err := url.Parse("http://test.me")
-	r.NoError(err)
+	exampleURL := "http://test.me"
 
 	validConfig, err := saml.NewConfig(
 		exampleURL,
 		exampleURL,
 		exampleURL,
-		exampleURL,
 	)
+	r.NoError(err)
 
 	cases := []struct {
 		name string
@@ -73,15 +72,10 @@ func Test_ServiceProvider_FetchMetadata_ErrorCases(t *testing.T) {
 	}))
 	defer s.Close()
 
-	fakeURL, err := url.Parse("http://cap.saml.fake")
-	r.NoError(err)
-
-	meta := fmt.Sprintf("%s/saml/metadata", s.URL)
-	metaURL, err := url.Parse(meta)
-	r.NoError(err)
+	fakeURL := "http://cap.saml.fake"
+	metaURL := fmt.Sprintf("%s/saml/metadata", s.URL)
 
 	cfg, err := saml.NewConfig(
-		fakeURL,
 		fakeURL,
 		fakeURL,
 		fakeURL,
@@ -90,18 +84,18 @@ func Test_ServiceProvider_FetchMetadata_ErrorCases(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		metadata *url.URL
+		metadata string
 		wantErr  string
 	}{
 		{
 			name:     "When the metadata can't be fetched",
 			metadata: fakeURL,
-			wantErr:  "saml.ServiceProvider.FetchMetdata: failed to fetch metadata:",
+			wantErr:  "saml.ServiceProvider.FetchIDPMetadata: failed to fetch identity provider metadata:",
 		},
 		{
 			name:     "When the metadata XML can't be parsed",
 			metadata: metaURL,
-			wantErr:  "saml.ServiceProvider.FetchMetdata: failed to parse metadata XML:",
+			wantErr:  "saml.ServiceProvider.FetchIDPMetadata: failed to parse identity provider XML metadata:",
 		},
 	}
 
@@ -112,7 +106,7 @@ func Test_ServiceProvider_FetchMetadata_ErrorCases(t *testing.T) {
 		r.NoError(err)
 
 		t.Run(c.name, func(_ *testing.T) {
-			got, err := provider.FetchMetadata()
+			got, err := provider.IDPMetadata()
 			r.Nil(got)
 			r.Error(err)
 			r.ErrorContains(err, c.wantErr)
@@ -123,17 +117,9 @@ func Test_ServiceProvider_FetchMetadata_ErrorCases(t *testing.T) {
 func Test_ServiceProvider_CreateMetadata(t *testing.T) {
 	r := require.New(t)
 
-	entityID, err := url.Parse("http://test.me/entity")
-	r.NoError(err)
-
-	acs, err := url.Parse("http://test.me/saml/acs")
-	r.NoError(err)
-
-	issuer, err := url.Parse("http://test.idp")
-	r.NoError(err)
-
-	meta, err := url.Parse("http://test.idp/metadata")
-	r.NoError(err)
+	entityID := "http://test.me/entity"
+	acs := "http://test.me/saml/acs"
+	meta := "http://test.me/sso/metadata"
 
 	now := time.Now()
 	validUntil := func() time.Time {
@@ -143,7 +129,6 @@ func Test_ServiceProvider_CreateMetadata(t *testing.T) {
 	cfg, err := saml.NewConfig(
 		entityID,
 		acs,
-		issuer,
 		meta,
 	)
 
@@ -190,11 +175,9 @@ func Test_ServiceProvider_CreateMetadata(t *testing.T) {
 func Test_CreateMetadata_Options(t *testing.T) {
 	r := require.New(t)
 
-	fakeURL, err := url.Parse("http://fake.test.url")
-	r.NoError(err)
+	fakeURL := "http://fake.test.url"
 
 	cfg, err := saml.NewConfig(
-		fakeURL,
 		fakeURL,
 		fakeURL,
 		fakeURL,
@@ -264,7 +247,7 @@ func Test_CreateMetadata_Options(t *testing.T) {
 			metadata.IndexedEndpoint{
 				Endpoint: metadata.Endpoint{
 					Binding:  core.ServiceBindingHTTPPost,
-					Location: fakeURL.String(),
+					Location: fakeURL,
 				},
 				Index: 1,
 			},


### PR DESCRIPTION
## Overview

This PR adds the ability to specify identity provider metadata as either an XML document or individual parameters. This is a common way that identity providers offer metadata to configure SAML service providers. I've introduced them as functional options to the `Config` struct.

Additionally, I've changed the `Config` struct to take in strings instead of `url.URL` for URL parameters. This felt more user friendly and aligns with my general experience using libraries that take in URLs (including `cap/oidc` and `cap/jwt`). I'm happy to change this back if there is disagreement.

## Testing

I've manually tested both XML identity provider metadata and individual parameters using Okta and the demo program. If everything looks reasonable, I'll add testing to this PR.