### PR TITLE
Fix validUntil attribute

### DIFF
--- a/saml/models/metadata/entity_descriptor.go
+++ b/saml/models/metadata/entity_descriptor.go
@@ -38,7 +38,7 @@ const (
 // DescriptorCommon defines common fields used in Entity- and EntitiesDescriptor.
 type DescriptorCommon struct {
 	ID            string        `xml:",attr,omitempty"`
-	ValidUntil    time.Time     `xml:"validUntil,attr,omitempty"`
+	ValidUntil    *time.Time    `xml:"validUntil,attr,omitempty"`
 	CacheDuration time.Duration `xml:"cacheDuration,attr,omitempty"`
 	Signature     *dsig.Signature
 }

--- a/saml/sp.go
+++ b/saml/sp.go
@@ -128,10 +128,9 @@ func (sp *ServiceProvider) CreateMetadata(opt ...Option) *metadata.EntityDescrip
 
 	spsso := metadata.EntityDescriptorSPSSO{}
 	spsso.EntityID = sp.cfg.EntityID
-	spsso.ValidUntil = validUntil
+	spsso.ValidUntil = &validUntil
 
 	spssoDescriptor := &metadata.SPSSODescriptor{}
-	spssoDescriptor.ValidUntil = validUntil
 	spssoDescriptor.ProtocolSupportEnumeration = metadata.ProtocolSupportEnumerationProtocol
 	spssoDescriptor.NameIDFormat = opts.nameIDFormats
 	spssoDescriptor.AuthnRequestsSigned = false // always false for now until request signing is supported.

--- a/saml/sp_test.go
+++ b/saml/sp_test.go
@@ -148,7 +148,7 @@ func Test_ServiceProvider_CreateMetadata(t *testing.T) {
 		t.Run(c.name, func(_ *testing.T) {
 			got := provider.CreateMetadata()
 
-			r.Equal(now, got.ValidUntil)
+			r.Equal(&now, got.ValidUntil)
 			r.Equal("http://test.me/entity", got.EntityID)
 
 			r.Len(got.SPSSODescriptor, 1)


### PR DESCRIPTION
`DescriptorCommon.ValidUntil` is a `time.Time` struct so the `omitempty` tag has no effect. This patch changes it to be a pointer so that it can be properly omitted.

Also in CreateMetadata() we set both `ValidUntil` on the `EntityDescriptorSPSSO` and the inner `SPSSODescriptor`. The spec says

	validUntil - Optional attribute indicates the expiration time of the
	metadata contained in the element and any contained elements.

so this is actually redundant.