### PR TITLE
Remove NameIDFormat default

### DIFF
--- a/saml/authn_request_test.go
+++ b/saml/authn_request_test.go
@@ -68,7 +68,8 @@ func Test_CreateAuthnRequest(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(_ *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
 			got, err := provider.CreateAuthnRequest(c.id, c.binding)
 			if c.err != "" {
 				r.Error(err)
@@ -113,7 +114,8 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 	provider, err := saml.NewServiceProvider(cfg)
 	r.NoError(err)
 
-	t.Run("When option AllowCreate is set", func(_ *testing.T) {
+	t.Run("When option AllowCreate is set", func(t *testing.T) {
+		r := require.New(t)
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,
@@ -126,7 +128,8 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 		r.True(got.NameIDPolicy.AllowCreate)
 	})
 
-	t.Run("When option WithNameIDFormat is set", func(_ *testing.T) {
+	t.Run("When option WithNameIDFormat is set", func(t *testing.T) {
+		r := require.New(t)
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,
@@ -140,7 +143,8 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 		r.Equal(core.NameIDFormatEmail, got.NameIDPolicy.Format)
 	})
 
-	t.Run("When option ForceAuthn is set", func(_ *testing.T) {
+	t.Run("When option ForceAuthn is set", func(t *testing.T) {
+		r := require.New(t)
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,
@@ -151,7 +155,8 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 		r.True(got.ForceAuthn)
 	})
 
-	t.Run("When option WithProtocolBinding is set", func(_ *testing.T) {
+	t.Run("When option WithProtocolBinding is set", func(t *testing.T) {
+		r := require.New(t)
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,
@@ -162,7 +167,8 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 		r.Equal(core.ServiceBindingHTTPRedirect, got.ProtocolBinding)
 	})
 
-	t.Run("When option WithAuthnContextRefs is set", func(_ *testing.T) {
+	t.Run("When option WithAuthnContextRefs is set", func(t *testing.T) {
+		r := require.New(t)
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,
@@ -179,7 +185,8 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 		r.Equal(core.ComparisonExact, got.RequestedAuthContext.Comparison)
 	})
 
-	t.Run("When more than one option is set", func(_ *testing.T) {
+	t.Run("When more than one option is set", func(t *testing.T) {
+		r := require.New(t)
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,

--- a/saml/config_test.go
+++ b/saml/config_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func Test_NewConfig(t *testing.T) {
-	r := require.New(t)
-
 	entityID := "http://test.me/entity"
 	acs := "http://test.me/sso/acs"
 	metadata := "http://test.me/sso/metadata"
@@ -54,7 +52,8 @@ func Test_NewConfig(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(_ *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
 			got, err := saml.NewConfig(
 				c.entityID,
 				c.acs,

--- a/saml/sp.go
+++ b/saml/sp.go
@@ -27,10 +27,7 @@ type metadataOptions struct {
 func metadataOptionsDefault() metadataOptions {
 	return metadataOptions{
 		wantAssertionsSigned: true,
-		nameIDFormats: []core.NameIDFormat{
-			core.NameIDFormatEmail,
-		},
-		acsServiceBinding: core.ServiceBindingHTTPPost,
+		acsServiceBinding:    core.ServiceBindingHTTPPost,
 	}
 }
 

--- a/saml/sp_test.go
+++ b/saml/sp_test.go
@@ -49,7 +49,8 @@ func Test_NewServiceProvider(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(_ *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
 			got, err := saml.NewServiceProvider(c.cfg)
 
 			if c.err != "" {
@@ -105,7 +106,8 @@ func Test_ServiceProvider_FetchMetadata_ErrorCases(t *testing.T) {
 		provider, err := saml.NewServiceProvider(cfg)
 		r.NoError(err)
 
-		t.Run(c.name, func(_ *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
 			got, err := provider.IDPMetadata()
 			r.Nil(got)
 			r.Error(err)
@@ -138,15 +140,25 @@ func Test_ServiceProvider_CreateMetadata(t *testing.T) {
 	r.NoError(err)
 
 	cases := []struct {
-		name string
+		name          string
+		nameIDFormats []core.NameIDFormat
 	}{
 		{
 			name: "",
 		},
+		{
+			name:          "email",
+			nameIDFormats: []core.NameIDFormat{core.NameIDFormatEmail},
+		},
 	}
 	for _, c := range cases {
-		t.Run(c.name, func(_ *testing.T) {
-			got := provider.CreateMetadata()
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
+			opts := []saml.Option{}
+			if c.nameIDFormats != nil {
+				opts = append(opts, saml.WithNameIDFormats(c.nameIDFormats))
+			}
+			got := provider.CreateMetadata(opts...)
 
 			r.Equal(now, got.ValidUntil)
 			r.Equal("http://test.me/entity", got.EntityID)
@@ -167,7 +179,7 @@ func Test_ServiceProvider_CreateMetadata(t *testing.T) {
 				"http://test.me/saml/acs",
 				got.SPSSODescriptor[0].AssertionConsumerService[0].Location,
 			)
-			r.Contains(got.SPSSODescriptor[0].NameIDFormat, core.NameIDFormatEmail)
+			r.Equal(got.SPSSODescriptor[0].NameIDFormat, c.nameIDFormats)
 		})
 	}
 }
@@ -186,7 +198,8 @@ func Test_CreateMetadata_Options(t *testing.T) {
 	provider, err := saml.NewServiceProvider(cfg)
 	r.NoError(err)
 
-	t.Run("When option InsecureWantAssertionsUnsigned is set", func(_ *testing.T) {
+	t.Run("When option InsecureWantAssertionsUnsigned is set", func(t *testing.T) {
+		r := require.New(t)
 		got := provider.CreateMetadata(
 			saml.InsecureWantAssertionsUnsigned(),
 		)
@@ -194,16 +207,17 @@ func Test_CreateMetadata_Options(t *testing.T) {
 		r.False(got.SPSSODescriptor[0].WantAssertionsSigned)
 	})
 
-	t.Run("When option WithAdditionalNameIDFormat is set", func(_ *testing.T) {
+	t.Run("When option WithAdditionalNameIDFormat is set", func(t *testing.T) {
+		r := require.New(t)
 		got := provider.CreateMetadata(
 			saml.WithAdditionalNameIDFormat(core.NameIDFormatTransient),
 		)
 
-		r.Len(got.SPSSODescriptor[0].NameIDFormat, 2)
-		r.Contains(got.SPSSODescriptor[0].NameIDFormat, core.NameIDFormatTransient)
+		r.Equal(got.SPSSODescriptor[0].NameIDFormat, []core.NameIDFormat{core.NameIDFormatTransient})
 	})
 
-	t.Run("When option WithNameIDFormats is set", func(_ *testing.T) {
+	t.Run("When option WithNameIDFormats is set", func(t *testing.T) {
+		r := require.New(t)
 		got := provider.CreateMetadata(
 			saml.WithNameIDFormats([]core.NameIDFormat{
 				core.NameIDFormatEntity,
@@ -218,7 +232,8 @@ func Test_CreateMetadata_Options(t *testing.T) {
 		})
 	})
 
-	t.Run("When option WithACSServiceBinding is set", func(_ *testing.T) {
+	t.Run("When option WithACSServiceBinding is set", func(t *testing.T) {
+		r := require.New(t)
 		got := provider.CreateMetadata(
 			saml.WithACSServiceBinding(core.ServiceBindingHTTPRedirect),
 		)
@@ -230,7 +245,8 @@ func Test_CreateMetadata_Options(t *testing.T) {
 		)
 	})
 
-	t.Run("When option WithAdditionalACSEndpoint is set", func(_ *testing.T) {
+	t.Run("When option WithAdditionalACSEndpoint is set", func(t *testing.T) {
+		r := require.New(t)
 		redirectEndpoint, err := url.Parse("http://cap.saml.test/acs/redirect")
 		r.NoError(err)
 


### PR DESCRIPTION
NameIDFormat is

	Zero or more elements of type anyURI that enumerate the name identifier
	formats supported by this system entity acting in this role. See Section
	8.3 of [SAMLCore] for some possible values for this element.

Vault (and I think Boundary also) do not need it to be an email, the name is used as an opaque string.

I suppose most public IdP will have an email for their user but private ones may not have one and use an employee ID or a username instead.

I think it's best to keep the default configuration empty to be compatible with such systems.

I also updated some subtests that where failing the parent test when an error occured. They now do fail the subtest itself instead. 