### PR TITLE
Set AllowCreate default value to true

### DIFF
--- a/saml/authn_request.go
+++ b/saml/authn_request.go
@@ -30,7 +30,7 @@ type authnRequestOptions struct {
 
 func authnRequestOptionsDefault() authnRequestOptions {
 	return authnRequestOptions{
-		allowCreate:     false,
+		allowCreate:     true,
 		nameIDFormat:    core.NameIDFormat(""),
 		forceAuthn:      false,
 		protocolBinding: core.ServiceBindingHTTPPost,
@@ -45,10 +45,10 @@ func getAuthnRequestOptions(opt ...Option) authnRequestOptions {
 
 // AllowCreate is a Boolean value used to indicate whether the identity provider is allowed, in the course
 // of fulfilling the request, to create a new identifier to represent the principal.
-func AllowCreate() Option {
+func AllowCreate(allow bool) Option {
 	return func(o interface{}) {
 		if o, ok := o.(*authnRequestOptions); ok {
-			o.allowCreate = true
+			o.allowCreate = allow
 		}
 	}
 }

--- a/saml/authn_request_test.go
+++ b/saml/authn_request_test.go
@@ -90,7 +90,8 @@ func Test_CreateAuthnRequest(t *testing.T) {
 				r.Equal(core.ServiceBindingHTTPPost, got.ProtocolBinding)
 				r.Equal("http://test.me/saml/acs", got.AssertionConsumerServiceURL)
 				r.Equal("http://test.me/entity", got.Issuer.Value)
-				r.Nil(got.NameIDPolicy)
+				r.NotNil(got.NameIDPolicy)
+				r.True(got.NameIDPolicy.AllowCreate)
 				r.Nil(got.RequestedAuthContext)
 				r.False(got.ForceAuthn)
 			}
@@ -117,13 +118,12 @@ func Test_CreateAuthnRequest_Options(t *testing.T) {
 		got, err := provider.CreateAuthnRequest(
 			"abc123",
 			core.ServiceBindingHTTPPost,
-			saml.AllowCreate(),
+			saml.AllowCreate(false),
 		)
 
 		r.NoError(err)
 
-		r.NotNil(got.NameIDPolicy)
-		r.True(got.NameIDPolicy.AllowCreate)
+		r.Nil(got.NameIDPolicy)
 	})
 
 	t.Run("When option WithNameIDFormat is set", func(_ *testing.T) {


### PR DESCRIPTION
The SAML2Core spec says for AllowCreate:

	A Boolean value used to indicate whether the requester grants to the identity provider, in the
	course of fulfilling the request, permission to create a new identifier or to associate an existing
	identifier representing the principal with the relying party. Defaults to "false"if not present or the entire
	element is omitted.

	[...]

	Requesters that do not make specific use of this attribute SHOULD generally set it to “true” to
	maximize interoperability.