### PR TITLE
feat (ldap): add worker pool for LDAP token group lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Canonical reference for changes, improvements, and bugfixes for cap.
 
+## Next
+
+* LDAP
+  * Add worker pool for LDAP token group lookups ([**PR**](https://github.com/hashicorp/cap/pull/98))
+
 ## 0.3.4
 
 ### Bug fixes


### PR DESCRIPTION
We've added worker pool to make looking up token groups more performant.  token groups have to be looked up individually, so if a user is a member of MANY groups it can be helpful to do these lookups concurrently vs serially. This is based on benchmarks and a subsequent implementation within vault's codebase for looking up token groups. 

See: https://github.com/hashicorp/vault/pull/22659