### PR TITLE
chore: update go version to a supported version

### DIFF
--- a/saml/go.mod
+++ b/saml/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/cap/saml
 
-go 1.19
+go 1.20
 
 require (
 	github.com/beevik/etree v1.2.0


### PR DESCRIPTION
1.19 is EOL, so updating to 1.20 -> we probably don't want to require 1.21 yet since it would no longer become a "recommendation" but rather a requirement.