### PR TITLE
saml: truncate issue instant to microseconds

### DIFF
--- a/saml/authn_request.go
+++ b/saml/authn_request.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/jonboulle/clockwork"
 
@@ -201,7 +202,7 @@ func (sp *ServiceProvider) CreateAuthnRequest(
 		ar.AssertionConsumerServiceURL = opts.assertionConsumerServiceURL
 	}
 
-	ar.IssueInstant = opts.clock.Now().UTC()
+	ar.IssueInstant = opts.clock.Now().Truncate(time.Microsecond).UTC()
 	ar.Destination = destination
 
 	ar.Issuer = &core.Issuer{}


### PR DESCRIPTION
This PR truncates the `IssueInstant` of the SAML `AuthNRequest` to microseconds. This enables our service provider to be compatible with SAML enterprise applications in Microsoft Entra (formerly Azure AD). I was able to reproduce the failure to parse the `IssueInstant` and verify this change fixes it in Vault.

This is needed because the `AuthnRequest` processing expects the `IssueInstant` to have the [round-trip format ("o")](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip) which has a max of 10^-7 second precision. Go `time.Now()` has [varying precision](https://github.com/golang/go/issues/41087) depending on which OS it's running on. On linux, the precision is 10^-9 (nanoseconds) which caused the parsing failure. Truncating to 10^-6 (microseconds) fixes it.