### PR TITLE
feat (config): add support for a http.RoundTripper

### DIFF
--- a/oidc/docs_test.go
+++ b/oidc/docs_test.go
@@ -95,7 +95,7 @@ func ExampleNewConfig() {
 	fmt.Println(pc)
 
 	// Output:
-	// &{your_client_id [REDACTED: client secret] [openid] http://your_issuer/ [RS256] [http://your_redirect_url/callback] []  <nil> <nil>}
+	// &{your_client_id [REDACTED: client secret] [openid] http://your_issuer/ [RS256] [http://your_redirect_url/callback] []  <nil> <nil> <nil>}
 }
 
 func ExampleWithProviderConfig() {
@@ -120,7 +120,7 @@ func ExampleWithProviderConfig() {
 	fmt.Println(string(val))
 
 	// Output:
-	// {"ClientID":"your_client_id","ClientSecret":"[REDACTED: client secret]","Scopes":["openid"],"Issuer":"https://your_issuer/","SupportedSigningAlgs":["RS256"],"AllowedRedirectURLs":["https://your_redirect_url/callback"],"Audiences":null,"ProviderCA":"","ProviderConfig":{"AuthURL":"https://your_issuer/authorize","TokenURL":"https://your_issuer/token","UserInfoURL":"https://your_issuer/userinfo","JWKSURL":"https://your_issuer/.well-known/jwks.json"}}
+	// {"ClientID":"your_client_id","ClientSecret":"[REDACTED: client secret]","Scopes":["openid"],"Issuer":"https://your_issuer/","SupportedSigningAlgs":["RS256"],"AllowedRedirectURLs":["https://your_redirect_url/callback"],"Audiences":null,"ProviderCA":"","RoundTripper":null,"ProviderConfig":{"AuthURL":"https://your_issuer/authorize","TokenURL":"https://your_issuer/token","UserInfoURL":"https://your_issuer/userinfo","JWKSURL":"https://your_issuer/.well-known/jwks.json"}}
 }
 
 func ExampleNewProvider() {

--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -714,6 +714,31 @@ func TestHTTPClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, c.Transport, p.client.Transport)
 	})
+	t.Run("check-transport-with-round-tripper", func(t *testing.T) {
+		testRt := newTestRoundTripper(t)
+		p := &Provider{
+			config: &Config{
+				RoundTripper: testRt,
+			},
+		}
+		c, err := p.HTTPClient()
+		require.NoError(t, err)
+		assert.Equal(t, c.Transport, p.client.Transport)
+	})
+	t.Run("err-both-ca-and-round-trippe", func(t *testing.T) {
+		_, testCaPem := TestGenerateCA(t, []string{"localhost"})
+
+		p := &Provider{
+			config: &Config{
+				ProviderCA:   testCaPem,
+				RoundTripper: newTestRoundTripper(t),
+			},
+		}
+		_, err := p.HTTPClient()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidParameter)
+		assert.ErrorContains(t, err, "you cannot specify config for both a ProviderCA and RoundTripper")
+	})
 }
 
 func TestProvider_UserInfo(t *testing.T) {


### PR DESCRIPTION
Add support for specifying an optional http.RoundTripper for a provider config.  If specified the http client will use the RoundTripper when making requests to the provider.