### PR TITLE
Add Endpoint() api call to oidc.Provider

### DIFF
--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -826,3 +826,9 @@ func unmarshalRespJSON(r *http.Response, body []byte, v interface{}) error {
 	}
 	return fmt.Errorf("%s: expected Content-Type = application/json, got %q and could not unmarshal it as JSON: %w", op, ct, err)
 }
+
+// Endpoint returns the oauth2 Endpoint information that the go-oidc
+// provider already knows about from its probe of the Discovery URL
+func (p *Provider) Endpoint() oauth2.Endpoint {
+        return p.provider.Endpoint()
+}

--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -1731,3 +1731,15 @@ func TestProvider_DiscoveryInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestProvider_Endpoint(t *testing.T) {
+	t.Parallel()
+	tp := StartTestProvider(t)
+	p := testNewProvider(t, "client-id", "client-secret", "redirect", tp)
+
+	endpoint := p.Endpoint()
+	assert := assert.New(t)
+	assert.NotEqual(endpoint.AuthURL, "")
+	assert.NotEqual(endpoint.DeviceAuthURL, "")
+	assert.NotEqual(endpoint.TokenURL, "")
+}

--- a/oidc/testing_provider.go
+++ b/oidc/testing_provider.go
@@ -1130,6 +1130,7 @@ func (p *TestProvider) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	const (
 		openidConfiguration = "/.well-known/openid-configuration"
 		authorize           = "/authorize"
+		deviceAuthorize     = "/deviceauthorize"
 		token               = "/token"
 		userInfo            = "/userinfo"
 		wellKnownJwks       = "/.well-known/jwks.json"
@@ -1160,6 +1161,7 @@ func (p *TestProvider) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		reply := struct {
 			Issuer                 string   `json:"issuer"`
 			AuthEndpoint           string   `json:"authorization_endpoint"`
+			DeviceAuthEndpoint     string   `json:"device_authorization_endpoint"`
 			TokenEndpoint          string   `json:"token_endpoint"`
 			JWKSURI                string   `json:"jwks_uri"`
 			UserinfoEndpoint       string   `json:"userinfo_endpoint,omitempty"`
@@ -1170,6 +1172,7 @@ func (p *TestProvider) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}{
 			Issuer:                 p.Addr(),
 			AuthEndpoint:           p.Addr() + authorize,
+			DeviceAuthEndpoint:     p.Addr() + deviceAuthorize,
 			TokenEndpoint:          p.Addr() + token,
 			JWKSURI:                p.Addr() + wellKnownJwks,
 			UserinfoEndpoint:       p.Addr() + userInfo,


### PR DESCRIPTION
This adds an `Endpoint()` api call to `oidc.Provider` which simply invokes the underlying coreos/go-oidc `Endpoint()` api.  That returns an `oauth2.Endpoint` object which since coreos/go-oidc#365 includes the `DeviceAuthURL` in addition to the `AuthURL` and `TokenURL` values read by oidc discovery.  This enables simplifying applications that need to use those URLs and avoids them having to separately discover that information, for example hashicorp/vault-plugin-auth-jwt#131 which adds the device flow to jwt/oidc authentication.