### PR TITLE
feat (oidc): add WithVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 Canonical reference for changes, improvements, and bugfixes for cap.
 
+## Next
+
+* feat (oidc): add WithVerifier ([PR #141](https://github.com/hashicorp/cap/pull/141))
+
+## 0.7.0
+
+* Add ability to the SAML test provider to create signed SAML responses by
+  @hcjulz ([PR: 135](https://github.com/hashicorp/cap/pull/135))
+* Bump golang.org/x/net from 0.22.0 to 0.23.0 by @dependabot ([PR #136](https://github.com/hashicorp/cap/pull/136))
+* feat (config): add support for a http.RoundTripper by @jimlambrt ([PR #137](https://github.com/hashicorp/cap/pull/137))
+* chore: update deps by @jimlambrt ([PR #138](https://github.com/hashicorp/cap/pull/138))
+
 ## 0.6.0
 
 * Add case insensitive user attribute keys configs for LDAP by @jasonodonnell in https://github.com/hashicorp/cap/pull/132
-* chore (oidc, jwt, ldap): update deps by @jimlambrt in https://github.com/hashicorp/cap/pull/133
+* chore (oidc, jwt, ldap): update deps by @jimlambrt in **https**://github.com/hashicorp/cap/pull/133
 * Add empty anonymous group search configs by @jasonodonnell in https://github.com/hashicorp/cap/pull/134
 
 ## 0.5.0

--- a/oidc/pkce_verifier_test.go
+++ b/oidc/pkce_verifier_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hashicorp/cap/oidc/internal/base62"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func TestNewCodeVerifier(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		got, err := NewCodeVerifier()
 		require.NoError(err)
-		assert.Equal(verifierLen, len(got.verifier))
+		assert.Equal(minVerifierLen, len(got.verifier))
 		assert.Equal(S256, got.Method())
 
 		challenge, err := CreateCodeChallenge(got)
@@ -52,4 +53,36 @@ func TestCreateCodeChallenge(t *testing.T) {
 		assert.Empty(challenge)
 		assert.True(errors.Is(err, ErrUnsupportedChallengeMethod))
 	})
+}
+
+func Test_WithVerifier(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+	v, err := base62.Random(43)
+	require.NoError(err)
+	got, err := NewCodeVerifier(WithVerifier(v))
+	require.NoError(err)
+	assert.Equal(v, got.Verifier())
+
+	// Test that the verifier is too short
+	v, err = base62.Random(42)
+	require.NoError(err)
+	_, err = NewCodeVerifier(WithVerifier(v))
+	require.Error(err)
+	assert.Contains(err.Error(), "verifier length is less than 43")
+
+	// Test that the verifier is too long
+	v, err = base62.Random(129)
+	require.NoError(err)
+	_, err = NewCodeVerifier(WithVerifier(v))
+	require.Error(err)
+	assert.Contains(err.Error(), "verifier length is greater than 128")
+
+	// Test that the verifier contains invalid characters
+	v, err = base62.Random(43)
+	require.NoError(err)
+	v = v + "!"
+	_, err = NewCodeVerifier(WithVerifier(v))
+	require.Error(err)
+	assert.Contains(err.Error(), "verifier contains invalid characters")
 }


### PR DESCRIPTION
This commit adds the WithVerifier option to the
oidc package. This option allows the user to
specify a custom verifier for the PKCE code
challenge.