### PR TITLE
ldap getUserDN handle multiple users

### DIFF
--- a/ldap/client.go
+++ b/ldap/client.go
@@ -736,9 +736,10 @@ func (c *Client) getUserDN(bindDN, username string) (string, error) {
 		if err != nil {
 			return userDN, fmt.Errorf("%s: LDAP search failed for detecting user (baseDN: %q / filter: %q): %w", op, c.conf.UserDN, filter, err)
 		}
-		for _, e := range result.Entries {
-			userDN = e.DN
+		if len(result.Entries) != 1 {
+			return "", fmt.Errorf("%s: LDAP search for user 0 or not unique", op)
 		}
+		userDN = result.Entries[0].DN
 	} else {
 		userDN = bindDN
 	}


### PR DESCRIPTION
This PR adds a check in the `ldap` package's `getUserDN` function that ensures the number of entries returned from the user DN LDAP search is one (in the same way we already handle multiple users in [`getUserBindDN`](https://github.com/hashicorp/cap/blob/5c3419e3e8ad01a7bc051f155964ab537a78cfec/ldap/client.go#L695-L698)). This should prevent authentication attacks that can leverage the fact that we currently return the last user DN if there are duplicate users.

The bulk of the changes are unit tests additions at the `getUserBindDN` and `getUserDN` level, which include test cases ensuring we error when there are multiple users returned.


Ticket: [VAULT-27421](https://hashicorp.atlassian.net/browse/VAULT-27421)

[VAULT-27421]: https://hashicorp.atlassian.net/browse/VAULT-27421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ