### PR TITLE
fix (ldap): fix slice append to be concurrent safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Canonical reference for changes, improvements, and bugfixes for cap.
 
 ## Next
 
+* fix (ldap): fix slice append to be concurrent safe when searching for ldap
+  groups ( [PR #167](https://github.com/hashicorp/cap/pull/167))
 
 ## 0.10.0
 * fix: use constant time comparison when comparing token hashes ([PR #165](https://github.com/hashicorp/cap/pull/165))


### PR DESCRIPTION
When searching for groups, ensure the warnings
slice is appended to in a concurrent safe manner.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ x ] I have documented a clear reason for, and description of, the change I am making.


