### PR TITLE
Further adjustments to WSL detection

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -28,11 +28,17 @@ func IsWSL() (bool, error) {
 		return false, fmt.Errorf("Unable to read /proc/1/cgroup: %w", err)
 	}
 
+	mountinfoData, err := ioutil.ReadFile("/proc/1/mountinfo")
+	if err != nil {
+		return false, fmt.Errorf("Unable to read /proc/1/mountinfo: %w", err)
+	}
+
+	isContainer := strings.Contains(strings.ToLower(string(mountinfoData)), "/containers/")
 	isDocker := strings.Contains(strings.ToLower(string(cgroupData)), "/docker/")
 	isLxc := strings.Contains(strings.ToLower(string(cgroupData)), "/lxc/")
 	isMsLinux := strings.Contains(strings.ToLower(string(procData)), "microsoft")
 
-	return isMsLinux && !(isDocker || isLxc), nil
+	return isMsLinux && !(isContainer || isDocker || isLxc), nil
 }
 
 // OpenURL opens the specified URL in the default browser of the user. Source:


### PR DESCRIPTION
It seems that using `/proc/1/cgroup` has been broken lately to detect docker. Other projects have been using `/proc/1/mountinfo` instead (see https://github.com/pre-commit/pre-commit/pull/3535). This PR extends the current detection mecanisms (without removing the existing ones).

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
