### PR TITLE
JWT: add optional KeySetSearcher callback to Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Canonical reference for changes, improvements, and bugfixes for cap.
 ## Next
 * fix (saml): always validate response and assertion signatures when signatures are present ([PR #180](https://github.com/hashicorp/cap/pull/180))
 
+* feat (jwt): add optional KeySetSearcher callback to Validator for dynamic KeySet lookup ([PR #187](https://github.com/hashicorp/cap/pull/187))
+
 ## 0.12.0
 * feat (oidc): add Claims for exposing provider server metadata ([PR #172](https://github.com/hashicorp/cap/pull/172))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 Canonical reference for changes, improvements, and bugfixes for cap.
 
 ## Next
-* fix (saml): always validate response and assertion signatures when signatures are present ([PR #180](https://github.com/hashicorp/cap/pull/180))
 
-* feat (jwt): add optional KeySetSearcher callback to Validator for dynamic KeySet lookup ([PR #187](https://github.com/hashicorp/cap/pull/187))
+* feat (jwt): add optional callback to dynamically fetch key sets in validator ([PR #187](https://github.com/hashicorp/cap/pull/187))
+* fix (saml): always validate response and assertion signatures when signatures are present ([PR #180](https://github.com/hashicorp/cap/pull/180))
 
 ## 0.12.0
 * feat (oidc): add Claims for exposing provider server metadata ([PR #172](https://github.com/hashicorp/cap/pull/172))

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,3 +1,4 @@
+// Copyright IBM Corp. 2020, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package jwt

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,4 +1,3 @@
-// Copyright IBM Corp. 2020, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package jwt
@@ -18,12 +17,24 @@ import (
 // for validating the "nbf" (Not Before) and "exp" (Expiration Time) claims.
 const DefaultLeewaySeconds = 150
 
+// KeySetSearcher is an optional callback function that can be used to
+// implement dynamic KeySet lookup based on the key ID (kid) from the JWT header.
+// If provided to the Validator, it will be called to locate the appropriate KeySet
+// for signature verification instead of iterating through a static list of KeySets.
+type KeySetSearcher func(ctx context.Context, keyID string) (KeySet, error)
+
 // Validator validates JSON Web Tokens (JWT) by providing signature
-// verification and claims set validation. Validator can contain either
-// a single or multiple KeySets and will attempt to verify the JWT by iterating
-// through the configured KeySets.
+// verification and claims set validation. Validator can be configured with either:
+//   - One or more KeySets: The validator will attempt to verify the JWT by iterating
+//     through the configured KeySets until one succeeds.
+//   - A KeySetSearcher callback: The validator will extract the key ID from the JWT header
+//     and use the callback to locate the appropriate KeySet for signature verification.
+//
+// Use NewValidator to create a Validator with KeySets, or NewValidatorWithKeySetSearcher
+// to create a Validator with a KeySet searcher callback.
 type Validator struct {
-	keySets []KeySet
+	keySets     []KeySet
+	keySearcher KeySetSearcher
 }
 
 // NewValidator returns a Validator that uses the given KeySet to verify JWT signatures.
@@ -40,6 +51,18 @@ func NewValidator(keySets ...KeySet) (*Validator, error) {
 
 	return &Validator{
 		keySets: keySets,
+	}, nil
+}
+
+// NewValidatorWithKeySetSearcher returns a Validator that uses a KeySetSearcher
+// callback to dynamically locate KeySets based on the key ID from the JWT header.
+func NewValidatorWithKeySetSearcher(keySetSearcher KeySetSearcher) (*Validator, error) {
+	if keySetSearcher == nil {
+		return nil, errors.New("keySetSearcher must not be nil")
+	}
+
+	return &Validator{
+		keySearcher: keySetSearcher,
 	}, nil
 }
 
@@ -129,12 +152,49 @@ func (v *Validator) validateAll(ctx context.Context, token string, expected Expe
 
 	// Ensure that the token is signed by at least one of the given key sets
 	var tokenVerified bool
-	for _, keySet := range v.keySets {
-		// First, verify the signature to ensure subsequent validation is against verified claims
+
+	if v.keySearcher != nil {
+		// Use the KeySetSearcher callback to dynamically locate the appropriate KeySet based on the JWT's kid header
+		var jws *jose.JSONWebSignature
+		jws, err = jose.ParseSigned(token)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing token: %w", err)
+		}
+		if len(jws.Signatures) == 0 {
+			return nil, fmt.Errorf("token must be signed")
+		}
+		if len(jws.Signatures) > 1 {
+			return nil, fmt.Errorf("token with multiple signatures not supported")
+		}
+
+		// Extract the kid (key ID) from the JWS header to locate the appropriate KeySet
+		keyID := jws.Signatures[0].Header.KeyID
+		if keyID == "" {
+			return nil, fmt.Errorf("token missing kid header parameter")
+		}
+
+		var keySet KeySet
+		keySet, err = v.keySearcher(ctx, keyID)
+		if err != nil {
+			return nil, fmt.Errorf("error searching for key set with kid %s: %w", keyID, err)
+		}
+		if keySet == nil {
+			return nil, fmt.Errorf("no key set found with kid %s", keyID)
+		}
+
 		allClaims, err = keySet.VerifySignature(ctx, token)
 		if err == nil {
 			tokenVerified = true
-			break
+		}
+	} else {
+		// Ensure that the token is signed by at least one of the given key sets
+		for _, keySet := range v.keySets {
+			// First, verify the signature to ensure subsequent validation is against verified claims
+			allClaims, err = keySet.VerifySignature(ctx, token)
+			if err == nil {
+				tokenVerified = true
+				break
+			}
 		}
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -5,13 +5,16 @@ package jwt
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/require"
 
@@ -639,6 +642,148 @@ func TestNewValidator(t *testing.T) {
 			require.NotNil(t, got)
 		})
 	}
+}
+
+// signJWTWithKid is a test helper that signs a JWT with the kid header properly set.
+func signJWTWithKid(t *testing.T, key crypto.PrivateKey, alg string, claims map[string]interface{}, keyID string) string {
+	t.Helper()
+	require := require.New(t)
+
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.SignatureAlgorithm(alg), Key: key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", keyID),
+	)
+	require.NoError(err)
+
+	raw, err := jwt.Signed(sig).
+		Claims(claims).
+		CompactSerialize()
+	require.NoError(err)
+	return raw
+}
+
+// TestNewValidatorWithKeySetSearcher tests cases for creating a new Validator with a KeySetSearcher.
+func TestNewValidatorWithKeySetSearcher(t *testing.T) {
+	type args struct {
+		searcher KeySetSearcher
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid key searcher",
+			args: args{
+				searcher: func(ctx context.Context, keyID string) (KeySet, error) {
+					return nil, nil // Just for constructor validation
+				},
+			},
+		},
+		{
+			name: "nil key searcher",
+			args: args{
+				searcher: nil,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewValidatorWithKeySetSearcher(tt.args.searcher)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+		})
+	}
+}
+
+// TestValidator_WithKeySetSearcher tests the KeySetSearcher code path.
+func TestValidator_WithKeySetSearcher(t *testing.T) {
+	tp := oidc.StartTestProvider(t)
+	tp.SetSigningKeys(priv, priv.Public(), oidc.RS256, testKeyID)
+
+	// Create the KeySet to be used to verify JWT signatures
+	keySet, err := NewJSONWebKeySet(context.Background(), tp.Addr()+wellKnownJWKS, tp.CACert())
+	require.NoError(t, err)
+
+	now := time.Now()
+	nowUnix := float64(now.Unix())
+	futureUnix := float64(now.Add(2 * jwt.DefaultLeeway).Unix())
+
+	t.Run("key searcher is called and signature verification succeeds", func(t *testing.T) {
+		claims := map[string]interface{}{
+			"iss": "https://example.com/",
+			"iat": nowUnix,
+			"exp": futureUnix,
+		}
+		token := signJWTWithKid(t, priv, string(RS256), claims, testKeyID)
+
+		// Track whether key searcher is called
+		called := false
+		keySearcher := func(ctx context.Context, keyID string) (KeySet, error) {
+			called = true
+			require.Equal(t, testKeyID, keyID, "searcher should be called with kid from JWT header")
+			return keySet, nil
+		}
+
+		validator, err := NewValidatorWithKeySetSearcher(keySearcher)
+		require.NoError(t, err)
+
+		got, err := validator.Validate(context.Background(), token, Expected{
+			Issuer: "https://example.com/",
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.True(t, called, "key searcher should have been called")
+		require.Equal(t, "https://example.com/", got["iss"])
+	})
+
+	t.Run("error from key searcher is propagated", func(t *testing.T) {
+		keySearcher := func(ctx context.Context, keyID string) (KeySet, error) {
+			return nil, errors.New("key set not found")
+		}
+
+		validator, err := NewValidatorWithKeySetSearcher(keySearcher)
+		require.NoError(t, err)
+
+		claims := map[string]interface{}{
+			"iss": "https://example.com/",
+			"iat": nowUnix,
+			"exp": futureUnix,
+		}
+		token := signJWTWithKid(t, priv, string(RS256), claims, testKeyID)
+
+		_, err = validator.Validate(context.Background(), token, Expected{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "key set not found")
+	})
+
+	t.Run("error when searcher returns nil KeySet", func(t *testing.T) {
+		keySearcher := func(ctx context.Context, keyID string) (KeySet, error) {
+			return nil, nil // Returns nil without error
+		}
+
+		validator, err := NewValidatorWithKeySetSearcher(keySearcher)
+		require.NoError(t, err)
+
+		claims := map[string]interface{}{
+			"iss": "https://example.com/",
+			"iat": nowUnix,
+			"exp": futureUnix,
+		}
+		token := signJWTWithKid(t, priv, string(RS256), claims, testKeyID)
+
+		_, err = validator.Validate(context.Background(), token, Expected{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no key set found")
+	})
 }
 
 // TestValidator_MultipleKeySets_Validate_Valid_JWT tests cases where a JWT is expected to be valid where the

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -5,7 +5,6 @@ package jwt
 
 import (
 	"context"
-	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
@@ -14,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/require"
 
@@ -644,24 +642,6 @@ func TestNewValidator(t *testing.T) {
 	}
 }
 
-// signJWTWithKid is a test helper that signs a JWT with the kid header properly set.
-func signJWTWithKid(t *testing.T, key crypto.PrivateKey, alg string, claims map[string]interface{}, keyID string) string {
-	t.Helper()
-	require := require.New(t)
-
-	sig, err := jose.NewSigner(
-		jose.SigningKey{Algorithm: jose.SignatureAlgorithm(alg), Key: key},
-		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", keyID),
-	)
-	require.NoError(err)
-
-	raw, err := jwt.Signed(sig).
-		Claims(claims).
-		CompactSerialize()
-	require.NoError(err)
-	return raw
-}
-
 // TestNewValidatorWithKeySetSearcher tests cases for creating a new Validator with a KeySetSearcher.
 func TestNewValidatorWithKeySetSearcher(t *testing.T) {
 	type args struct {
@@ -720,7 +700,7 @@ func TestValidator_WithKeySetSearcher(t *testing.T) {
 			"iat": nowUnix,
 			"exp": futureUnix,
 		}
-		token := signJWTWithKid(t, priv, string(RS256), claims, testKeyID)
+		token := oidc.TestSignJWT(t, priv, string(RS256), claims, []byte(testKeyID))
 
 		// Track whether key searcher is called
 		called := false
@@ -756,7 +736,7 @@ func TestValidator_WithKeySetSearcher(t *testing.T) {
 			"iat": nowUnix,
 			"exp": futureUnix,
 		}
-		token := signJWTWithKid(t, priv, string(RS256), claims, testKeyID)
+		token := oidc.TestSignJWT(t, priv, string(RS256), claims, []byte(testKeyID))
 
 		_, err = validator.Validate(context.Background(), token, Expected{})
 
@@ -777,7 +757,7 @@ func TestValidator_WithKeySetSearcher(t *testing.T) {
 			"iat": nowUnix,
 			"exp": futureUnix,
 		}
-		token := signJWTWithKid(t, priv, string(RS256), claims, testKeyID)
+		token := oidc.TestSignJWT(t, priv, string(RS256), claims, []byte(testKeyID))
 
 		_, err = validator.Validate(context.Background(), token, Expected{})
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/require"
 
@@ -763,6 +765,88 @@ func TestValidator_WithKeySetSearcher(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no key set found")
+	})
+
+	t.Run("error when JWT is missing kid header", func(t *testing.T) {
+		keySearcher := func(ctx context.Context, keyID string) (KeySet, error) {
+			return keySet, nil
+		}
+
+		validator, err := NewValidatorWithKeySetSearcher(keySearcher)
+		require.NoError(t, err)
+
+		claims := map[string]interface{}{
+			"iss": "https://example.com/",
+			"iat": nowUnix,
+			"exp": futureUnix,
+		}
+		// Create JWT without kid header by passing nil as keyID
+		token := oidc.TestSignJWT(t, priv, string(RS256), claims, nil)
+
+		_, err = validator.Validate(context.Background(), token, Expected{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token missing kid header parameter")
+	})
+
+	t.Run("error when JWT is malformed", func(t *testing.T) {
+		keySearcher := func(ctx context.Context, keyID string) (KeySet, error) {
+			return keySet, nil
+		}
+
+		validator, err := NewValidatorWithKeySetSearcher(keySearcher)
+		require.NoError(t, err)
+
+		// Use a malformed JWT token
+		malformedToken := "not.a.valid.jwt.token"
+
+		_, err = validator.Validate(context.Background(), malformedToken, Expected{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error parsing token")
+	})
+
+	t.Run("error when JWT has multiple signatures", func(t *testing.T) {
+		keySearcher := func(ctx context.Context, keyID string) (KeySet, error) {
+			return keySet, nil
+		}
+
+		validator, err := NewValidatorWithKeySetSearcher(keySearcher)
+		require.NoError(t, err)
+
+		// Create a valid JWT and then modify it to have multiple signatures
+		claims := map[string]interface{}{
+			"iss": "https://example.com/",
+			"iat": nowUnix,
+			"exp": futureUnix,
+		}
+		token := oidc.TestSignJWT(t, priv, string(RS256), claims, []byte(testKeyID))
+
+		// Parse the token and duplicate its signature
+		parsedJWS, err := jose.ParseSigned(token)
+		require.NoError(t, err)
+
+		// Manually create a JSON with duplicate signatures
+		var jwsMap map[string]interface{}
+		err = json.Unmarshal([]byte(parsedJWS.FullSerialize()), &jwsMap)
+		require.NoError(t, err)
+
+		sig := jwsMap["signature"].(string)
+		protected := jwsMap["protected"].(string)
+
+		// Create JSON with two identical signatures
+		multiSigJSON := fmt.Sprintf(`{
+			"payload": %q,
+			"signatures": [
+				{"protected": %q, "signature": %q},
+				{"protected": %q, "signature": %q}
+			]
+		}`, jwsMap["payload"], protected, sig, protected, sig)
+
+		_, err = validator.Validate(context.Background(), multiSigJSON, Expected{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token with multiple signatures not supported")
 	})
 }
 

--- a/oidc/testing.go
+++ b/oidc/testing.go
@@ -46,7 +46,7 @@ func TestSignJWT(t TestingT, key crypto.PrivateKey, alg string, claims interface
 
 	hdr := map[jose.HeaderKey]interface{}{}
 	if keyID != nil {
-		hdr["key_id"] = string(keyID)
+		hdr["kid"] = string(keyID)
 	}
 
 	sig, err := jose.NewSigner(


### PR DESCRIPTION
Adds an optional `KeySetSearcher` callback to the JWT Validator to support dynamic KeySet lookup based on the JWT's key ID (kid) header. When provided, the Validator extracts the kid from the JWT header and calls the callback to retrieve the appropriate KeySet, instead of the default sequential KeySet verification.

Motivation:
Vault's JWT auth plugin uses CAP for JWT validation, which delegates signature verification to `go-oidc`. The current flow checks each keyset's cache and if the key is not found, fetches from the JWKS URL before moving to the next keyset. This sequential fetch-per-keyset behavior was causing a performance issue for a customer with multiple JWKS endpoints configured.

This change adds a `KeySetSearcher` callback to CAP's Validator, allowing the plugin to implement custom KeySet lookup logic. The Validator handles all JWT parsing and security validation (extracting the kid from the JWT header, verifying the signature with the returned KeySet), while the callback provides the logic for locating the appropriate KeySet. This enables implementations to check all caches before refreshing any keys from remote JWKS URLs.

The `NewValidatorWithKeySetSearcher` constructor has been added to avoid modifying the existing `NewValidator`. Existing callers using `NewValidator` are completely unaffected.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
