### PR TITLE
hardening: guard against homoglyph keys during claims (un)marshaling

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v3"
@@ -17,6 +18,11 @@ import (
 // DefaultLeewaySeconds defines the amount of leeway that's used by default
 // for validating the "nbf" (Not Before) and "exp" (Expiration Time) claims.
 const DefaultLeewaySeconds = 150
+
+// registeredClaimNames are the JWT registered claim names (see RFC 7519,
+// section 4.1) that this package validates by decoding a token's claims into a
+// go-jose jwt.Claims struct.
+var registeredClaimNames = []string{"iss", "sub", "aud", "exp", "nbf", "iat", "jti"}
 
 // KeySetSearcher is an optional callback function that can be used to
 // implement dynamic KeySet lookup based on the key ID (kid) from the JWT header.
@@ -203,6 +209,18 @@ func (v *Validator) validateAll(ctx context.Context, token string, expected Expe
 		return nil, fmt.Errorf("error verifying token signature: %w", err)
 	}
 
+	// Guard against claims-confusion before trusting the struct-based
+	// validation below. The registered claims are validated by decoding
+	// allClaims into a jwt.Claims struct, but allClaims (a map) is also what's
+	// ultimately returned to the caller. If the token contains a key that isn't
+	// byte-identical to a registered claim name but collides with it under case
+	// folding (e.g. the Unicode long s "ſub" folding to "sub"), the value
+	// validated via the struct can differ from the value the caller reads from
+	// the map. Reject such tokens.
+	if err := checkRegisteredClaimCollisions(allClaims); err != nil {
+		return nil, err
+	}
+
 	// Validate the signing algorithm in the JWS header
 	if err := validateSigningAlgorithm(token, expected.SigningAlgorithms); err != nil {
 		return nil, fmt.Errorf("invalid algorithm (alg) header parameter: %w", err)
@@ -306,6 +324,37 @@ func (v *Validator) validateAll(ctx context.Context, token string, expected Expe
 	}
 
 	return allClaims, nil
+}
+
+// checkRegisteredClaimCollisions guards against a claims-confusion that arises
+// from the interaction of three encoding/json behaviors:
+//
+//   - A JWT's claims are decoded into a map[string]interface{}, which only
+//     deduplicates keys that match byte-for-byte.
+//   - Those claims are then re-marshaled and decoded into a jwt.Claims struct
+//     for validation. Struct field matching is case-insensitive under Unicode
+//     simple case folding, so a key such as "ſub" (U+017F, LATIN SMALL LETTER
+//     LONG S) or "SUB" populates the same field as "sub".
+//   - json.Marshal emits object keys sorted by UTF-8 byte value, so a folded
+//     variant like "ſub" (0xC5BF) sorts after its ASCII twin "sub" (0x73) and
+//     therefore wins when the struct field is populated.
+//
+// The effect is that the value used for validation (read from the struct) can
+// differ from the value returned to the caller (read from the map).
+func checkRegisteredClaimCollisions(allClaims map[string]any) error {
+	for key := range allClaims {
+		for _, name := range registeredClaimNames {
+			if key == name {
+				// exact, byte-for-byte match: this is the canonical registered
+				// claim.
+				continue
+			}
+			if strings.EqualFold(key, name) {
+				return fmt.Errorf("ambiguous claim: key %q collides with registered claim %q under case folding", key, name)
+			}
+		}
+	}
+	return nil
 }
 
 // validateSigningAlgorithm checks whether the JWS "alg" (Algorithm) header

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -5,6 +5,7 @@ package jwt
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
@@ -1920,6 +1921,188 @@ func Test_validateSigningAlgorithm(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+// TestValidator_ClaimsConfusion_Rejected verifies that a JWT which smuggles a
+// Unicode homoglyph (or ASCII case variant) of a registered claim name past the
+// struct-based validation is rejected end-to-end.
+//
+// Without the guard, a payload such as {"sub":"root","ſub":"anon"} validates as
+// Subject=="anon" (the "ſub" homoglyph, U+017F, folds to "sub" and, because
+// json.Marshal sorts it after the ASCII "sub", overrides the struct field)
+// while the map handed back to the caller still reports map["sub"]=="root".
+func TestValidator_ClaimsConfusion_Rejected(t *testing.T) {
+	now := time.Now()
+	nowUnix := float64(now.Unix())
+	futureUnix := float64(now.Add(2 * time.Hour).Unix())
+
+	keySet, err := NewStaticKeySet([]crypto.PublicKey{priv.Public()})
+	require.NoError(t, err)
+
+	validator, err := NewValidator(keySet)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		claims   map[string]any
+		expected Expected
+	}{
+		{
+			name: "long s homoglyph of sub",
+			claims: map[string]any{
+				"sub":      "root", // canonical key the caller reads
+				"\u017Fub": "anon", // "ſub": folds to "sub", wins the struct field
+				"iat":      nowUnix,
+				"exp":      futureUnix,
+			},
+			expected: Expected{Subject: "anon"},
+		},
+		{
+			name: "long s homoglyph of iss",
+			claims: map[string]any{
+				"iss":      "https://evil.example/", // canonical key the caller reads
+				"i\u017Fs": "https://good.example/", // "iſs": folds to "iss"
+				"iat":      nowUnix,
+				"exp":      futureUnix,
+			},
+			expected: Expected{Issuer: "https://good.example/"},
+		},
+		{
+			name: "ascii uppercase variant of sub",
+			claims: map[string]any{
+				"sub": "root",
+				"SUB": "anon",
+				"iat": nowUnix,
+				"exp": futureUnix,
+			},
+			expected: Expected{Subject: "anon"},
+		},
+		{
+			name: "lone homoglyph without canonical twin",
+			claims: map[string]any{
+				"\u017Fub": "anon", // "ſub" alone still validates the struct field
+				"iat":      nowUnix,
+				"exp":      futureUnix,
+			},
+			expected: Expected{Subject: "anon"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := oidc.TestSignJWT(t, priv, string(RS256), tt.claims, []byte(testKeyID))
+
+			got, err := validator.Validate(context.Background(), token, tt.expected)
+			require.Error(t, err)
+			require.Nil(t, got)
+			require.Contains(t, err.Error(), "collides with registered claim")
+		})
+	}
+}
+
+// TestValidator_ClaimsConfusion_BenignTokenStillValid ensures the guard does
+// not reject ordinary tokens: canonical registered claims and unrelated custom
+// claims (including non-registered Unicode keys) pass through and are returned
+// unchanged.
+func TestValidator_ClaimsConfusion_BenignTokenStillValid(t *testing.T) {
+	now := time.Now()
+	nowUnix := float64(now.Unix())
+	futureUnix := float64(now.Add(2 * time.Hour).Unix())
+
+	keySet, err := NewStaticKeySet([]crypto.PublicKey{priv.Public()})
+	require.NoError(t, err)
+
+	validator, err := NewValidator(keySet)
+	require.NoError(t, err)
+
+	claims := map[string]any{
+		"iss":       "https://example.com/",
+		"sub":       "alice@example.com",
+		"role":      "admin", // custom claim, must pass through untouched
+		"n\u00e1me": "Alice", // "náme": non-registered Unicode key, must not be flagged
+		"iat":       nowUnix,
+		"exp":       futureUnix,
+	}
+	token := oidc.TestSignJWT(t, priv, string(RS256), claims, []byte(testKeyID))
+
+	got, err := validator.Validate(context.Background(), token, Expected{
+		Issuer:  "https://example.com/",
+		Subject: "alice@example.com",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/", got["iss"])
+	require.Equal(t, "alice@example.com", got["sub"])
+	require.Equal(t, "admin", got["role"])
+	require.Equal(t, "Alice", got["n\u00e1me"])
+}
+
+// Test_checkRegisteredClaimCollisions unit-tests the collision guard directly.
+func Test_checkRegisteredClaimCollisions(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  map[string]any
+		wantErr bool
+	}{
+		{
+			name: "only canonical registered claims",
+			claims: map[string]any{
+				"iss": "a", "sub": "b", "aud": "c",
+				"exp": 1, "nbf": 2, "iat": 3, "jti": "d",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "custom non-colliding claims",
+			claims:  map[string]any{"sub": "b", "role": "admin", "email": "x@y.z"},
+			wantErr: false,
+		},
+		{
+			name:    "empty claims",
+			claims:  map[string]any{},
+			wantErr: false,
+		},
+		{
+			name:    "non-registered unicode key",
+			claims:  map[string]any{"n\u00e1me": "x"}, // "náme"
+			wantErr: false,
+		},
+		{
+			name:    "long s homoglyph of sub",
+			claims:  map[string]any{"sub": "x", "\u017Fub": "y"}, // "ſub"
+			wantErr: true,
+		},
+		{
+			name:    "long s homoglyph of iss without canonical twin",
+			claims:  map[string]any{"i\u017Fs": "y"}, // "iſs"
+			wantErr: true,
+		},
+		{
+			name:    "ascii uppercase SUB",
+			claims:  map[string]any{"SUB": "y"},
+			wantErr: true,
+		},
+		{
+			name:    "ascii mixed case Iss",
+			claims:  map[string]any{"Iss": "y"},
+			wantErr: true,
+		},
+		{
+			name:    "uppercase AUD",
+			claims:  map[string]any{"AUD": "y"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkRegisteredClaimCollisions(tt.claims)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This changeset introduces a small hardening of the library against JWT "claims
confusion" vulnerability, where a Unicode homoglyph of a registered claim name
could make struct-based validation and the returned map disagree. 

Internal ref: https://hashicorp.atlassian.net/browse/SECVULN-47712

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
