### PR TITLE
feat(oidc): Creation Of Azure Package For Resolving Group Overage Claims

### DIFF
--- a/oidc/azure/azure.go
+++ b/oidc/azure/azure.go
@@ -1,0 +1,238 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// azureGroups is the structured response from the Microsoft Graph API when fetching group IDs for a user.
+// The Value field contains a slice of group IDs.
+type azureGroups struct {
+	Value []string `json:"value"`
+}
+
+const (
+
+	// Deprecated: The Azure AD (AAD) Graph API hosts.
+	azureADGraphHost   = "graph.windows.net"
+	azureADGraphUSHost = "graph.microsoftazure.us"
+	azureADGraphCNHost = "graph.chinacloudapi.cn"
+
+	// The Microsoft Graph API hosts.
+	microsoftGraphHost      = "graph.microsoft.com"
+	microsoftGraphUSHost    = "graph.microsoft.us"
+	microsoftGraphUSDodHost = "dod-graph.microsoft.us"
+	microsoftGraphCNHost    = "microsoftgraph.chinacloudapi.cn"
+
+	// getMemberObjectsPath is the path to the Microsoft Graph API endpoint for
+	// retrieving the groups a user is a member of.
+	getMemberObjectsPath = "/v1.0/me/getMemberObjects"
+
+	// claimNameField and claimsSourceField are the Azure distributed claims fields.
+	claimNameField   = "_claim_names"
+	claimSourceField = "_claim_sources"
+
+	// claimGroupsField is the Azure defined key within _claim_names that indicates
+	// the groups claim has been distributed due to token size constraints.
+	claimGroupsField = "groups"
+
+	// claimEndpointField is the Azure defined key within _claim_sources that indicates
+	// the endpoint to call to retrieve the distributed groups claim.
+	claimEndpointField = "endpoint"
+)
+
+// supportedGraphHosts maps each supported Graph API host to its actively
+// supported Microsoft Graph API equivalent, including deprecated Azure AD
+// Graph API hosts.
+var supportedGraphHosts = map[string]string{
+	azureADGraphHost:        microsoftGraphHost,
+	azureADGraphUSHost:      microsoftGraphUSHost,
+	azureADGraphCNHost:      microsoftGraphCNHost,
+	microsoftGraphHost:      microsoftGraphHost,
+	microsoftGraphUSHost:    microsoftGraphUSHost,
+	microsoftGraphUSDodHost: microsoftGraphUSDodHost,
+	microsoftGraphCNHost:    microsoftGraphCNHost,
+}
+
+// ResolveGroupClaims will detect an Azure groups overage indicator in the
+// provided claims and fetch the full list of group IDs from the Microsoft
+// Graph API using the provided OAuth2 token. When no overage indicator is
+// present, it returns an empty map. On success, the returned map contains
+// a "groups" key populated with the user's group IDs.
+func ResolveGroupClaims(ctx context.Context, client *http.Client, token *oauth2.Token, claims map[string]any) (map[string]any, error) {
+	const op = "azure.ResolveGroupClaims"
+	switch {
+	case client == nil:
+		return nil, fmt.Errorf("%s: nil http client: %w", op, ErrNilParameter)
+	case token == nil:
+		return nil, fmt.Errorf("%s: nil oauth2 token: %w", op, ErrNilParameter)
+	case claims == nil:
+		return nil, fmt.Errorf("%s: nil claims map: %w", op, ErrNilParameter)
+	case len(claims) == 0:
+		// If there are no claims, there are certainly no distributed claims to resolve.
+		return map[string]any{}, nil
+	}
+
+	host, ok := fetchGroupsOverageHost(claims)
+	if !ok {
+		// If there is no overage claim, there is nothing to resolve.
+		return map[string]any{}, nil
+	}
+
+	endpoint, err := graphGroupsEndpoint(host)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to resolve graph groups endpoint: %w", op, err)
+	}
+
+	groupIDs, err := fetchGroupIDs(ctx, client, token, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to fetch group IDs from graph API: %w", op, err)
+	}
+
+	return map[string]any{
+		claimGroupsField: groupIDs,
+	}, nil
+}
+
+// knownGraphHost reports whether host is within the known set of Microsoft
+// Graph API hosts, including deprecated Azure AD Graph API hosts that Azure
+// may still emit.
+func knownGraphHost(host string) bool {
+	_, ok := supportedGraphHosts[host]
+	return ok
+}
+
+// fetchGroupsOverageHost fetches the Azure Graph API host from the provided
+// overage claims if they are present and match against a known set of
+// Microsoft supported endpoints. Example overage claim structure:
+//
+//	{
+//	    "_claim_names": {
+//	        "groups": "src1"
+//	    },
+//	    "_claim_sources": {
+//	        "src1": {
+//	            "endpoint": "https://graph.microsoft.com/v1.0/users/{userID}/getMemberObjects"
+//	        }
+//	    }
+//	}
+func fetchGroupsOverageHost(claims map[string]any) (string, bool) {
+	if len(claims) == 0 {
+		return "", false
+	}
+	// Check for the presence of the _claim_names field and ensure it's a map.
+	claimNames, ok := claims[claimNameField].(map[string]any)
+	if !ok || claimNames == nil {
+		return "", false
+	}
+	// Fetch the source key for the groups claim from _claim_names.
+	sourceKey, ok := claimNames[claimGroupsField].(string)
+	if !ok || sourceKey == "" {
+		return "", false
+	}
+	// Check for the presence of the _claim_sources field and ensure it's a map.
+	sources, ok := claims[claimSourceField].(map[string]any)
+	if !ok || sources == nil {
+		return "", false
+	}
+
+	// Fetch the source for the groups claim from _claim_sources retrieved using the sourceKey from _claim_names.
+	source, ok := sources[sourceKey].(map[string]any)
+	if !ok || source == nil {
+		return "", false
+	}
+
+	// Fetch the endpoint for the groups claim within _claim_sources.
+	endpoint, ok := source[claimEndpointField].(string)
+	if !ok || endpoint == "" {
+		return "", false
+	}
+
+	// Parse the endpoint URL to extract the host and validate it against known Graph API hosts.
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", false
+	}
+
+	if !knownGraphHost(u.Host) {
+		return "", false
+	}
+
+	return u.Host, true
+}
+
+// graphGroupsEndpoint returns the Microsoft Graph API endpoint for retrieving a user's
+// groups, based on the provided Graph host.
+func graphGroupsEndpoint(host string) (*url.URL, error) {
+	const op = "azure.graphGroupsEndpoint"
+	if host == "" {
+		return nil, fmt.Errorf("%s: %w", op, ErrInvalidParameter)
+	}
+
+	h, ok := supportedGraphHosts[host]
+	if !ok {
+		return nil, fmt.Errorf("%s: unknown graph host %s: %w", op, host, ErrInvalidParameter)
+	}
+
+	url, err := url.Parse(fmt.Sprintf("https://%s%s", h, getMemberObjectsPath))
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to parse graph endpoint URL: %w", op, err)
+	}
+
+	return url, nil
+}
+
+// fetchGroupIDs calls the Microsoft Graph API at the given endpoint and returns
+// a slice of group IDs the authenticated user belongs to.
+func fetchGroupIDs(ctx context.Context, client *http.Client, token *oauth2.Token, endpoint *url.URL) ([]string, error) {
+	const op = "azure.fetchGroupIDs"
+	switch {
+	case client == nil:
+		return nil, fmt.Errorf("%s: nil http client: %w", op, ErrNilParameter)
+	case token == nil:
+		return nil, fmt.Errorf("%s: nil oauth2 token: %w", op, ErrNilParameter)
+	case endpoint == nil:
+		return nil, fmt.Errorf("%s: missing endpoint: %w", op, ErrInvalidParameter)
+	}
+
+	payload := strings.NewReader("{\"securityEnabledOnly\": false}")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), payload)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to create request: %w", op, err)
+	}
+
+	req.Header.Add("content-type", "application/json")
+	token.SetAuthHeader(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: graph API request failed: %w", op, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: graph API request failed with status %d", op, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to read the graph API response body: %w", op, err)
+	}
+
+	var groups azureGroups
+	if err := json.Unmarshal(body, &groups); err != nil {
+		return nil, fmt.Errorf("%s: failed to unmarshal the graph API response body: %w", op, err)
+	}
+
+	return groups.Value, nil
+}

--- a/oidc/azure/azure_test.go
+++ b/oidc/azure/azure_test.go
@@ -1,0 +1,499 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package azure
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// testRoundTripper is a function type that implements http.RoundTripper,
+// allowing tests to supply mocked HTTP responses via a closure.
+type testRoundTripper func(r *http.Request) (*http.Response, error)
+
+func (f testRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// testGraphClient returns an *http.Client whose transport returns a canned
+// HTTP response with the provided status code and body.
+func testGraphClient(status int, body string) *http.Client {
+	return &http.Client{
+		Transport: testRoundTripper(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+}
+
+// testOverageClaims returns a mocked set of overage claims for the provided
+// graph API host.
+func testOverageClaims(t *testing.T, host string) map[string]any {
+	t.Helper()
+	require.NotEmptyf(t, host, "graph API host must be provided")
+
+	return map[string]any{
+		claimNameField: map[string]any{
+			claimGroupsField: "src1",
+		},
+		claimSourceField: map[string]any{
+			"src1": map[string]any{
+				claimEndpointField: fmt.Sprintf("https://%s%s", host, getMemberObjectsPath),
+			},
+		},
+	}
+}
+
+func Test_KnownGraphHost(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{
+			name: "empty host",
+			host: "",
+			want: false,
+		},
+		{
+			name: "unknown host",
+			host: "unknown.host.com",
+			want: false,
+		},
+		{
+			name: "Azure AD Graph host",
+			host: azureADGraphHost,
+			want: true,
+		},
+		{
+			name: "Azure AD Graph US host",
+			host: azureADGraphUSHost,
+			want: true,
+		},
+		{
+			name: "Azure AD Graph CN host",
+			host: azureADGraphCNHost,
+			want: true,
+		},
+		{
+			name: "Microsoft Graph host",
+			host: microsoftGraphHost,
+			want: true,
+		},
+		{
+			name: "Microsoft Graph US host",
+			host: microsoftGraphUSHost,
+			want: true,
+		},
+		{
+			name: "Microsoft Graph US DoD host",
+			host: microsoftGraphUSDodHost,
+			want: true,
+		},
+		{
+			name: "Microsoft Graph CN host",
+			host: microsoftGraphCNHost,
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := knownGraphHost(tc.host)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_FetchGroupsOverageHost(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		claims       map[string]any
+		want         bool
+		expectedHost string
+	}{
+		{
+			name:         "nil claims",
+			claims:       nil,
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name:         "empty claims",
+			claims:       map[string]any{},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name: "missing claim names field",
+			claims: map[string]any{
+				claimNameField: nil,
+			},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name: "missing claim groups field",
+			claims: map[string]any{
+				claimNameField: map[string]any{
+					claimGroupsField: nil,
+				},
+			},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name: "missing claim source field",
+			claims: map[string]any{
+				claimNameField: map[string]any{
+					claimGroupsField: "src1",
+				},
+			},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name: "missing source key field",
+			claims: map[string]any{
+				claimNameField: map[string]any{
+					claimGroupsField: "src1",
+				},
+				claimSourceField: map[string]any{},
+			},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name: "missing endpoint field",
+			claims: map[string]any{
+				claimNameField: map[string]any{
+					claimGroupsField: "src1",
+				},
+				claimSourceField: map[string]any{
+					"src1": map[string]any{},
+				},
+			},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name: "invalid endpoint url",
+			claims: map[string]any{
+				claimNameField: map[string]any{
+					claimGroupsField: "src1",
+				},
+				claimSourceField: map[string]any{
+					"src1": map[string]any{
+						claimEndpointField: "://bad-url",
+					},
+				},
+			},
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name:         "unknown graph host",
+			claims:       testOverageClaims(t, "unknown.host.com"),
+			want:         false,
+			expectedHost: "",
+		},
+		{
+			name:         "valid graph API host",
+			claims:       testOverageClaims(t, microsoftGraphHost),
+			want:         true,
+			expectedHost: microsoftGraphHost,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			host, ok := fetchGroupsOverageHost(tc.claims)
+			if !tc.want {
+				require.False(t, ok)
+				assert.Empty(t, host)
+				return
+			}
+			require.True(t, ok)
+			assert.Equal(t, tc.expectedHost, host)
+		})
+	}
+}
+
+func Test_GraphGroupsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		host         string
+		wantErr      error
+		wantEndpoint *url.URL
+	}{
+		{
+			name:         "empty host",
+			host:         "",
+			wantErr:      ErrInvalidParameter,
+			wantEndpoint: nil,
+		},
+		{
+			name:         "unknown host",
+			host:         "unknown.host.com",
+			wantErr:      ErrInvalidParameter,
+			wantEndpoint: nil,
+		},
+		{
+			name: "valid graph API host",
+			host: "graph.microsoft.com",
+			wantEndpoint: func() *url.URL {
+				u, err := url.Parse(fmt.Sprintf("https://%s%s", microsoftGraphHost, getMemberObjectsPath))
+				require.NoError(t, err)
+				return u
+			}(),
+		},
+		{
+			name: "valid deprecated graph API host",
+			host: "graph.windows.net",
+			wantEndpoint: func() *url.URL {
+				u, err := url.Parse(fmt.Sprintf("https://%s%s", microsoftGraphHost, getMemberObjectsPath))
+				require.NoError(t, err)
+				return u
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			endpoint, err := graphGroupsEndpoint(tc.host)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.Empty(t, endpoint)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantEndpoint, endpoint)
+		})
+	}
+}
+
+func Test_FetchGroupIDs(t *testing.T) {
+	t.Parallel()
+
+	testToken := &oauth2.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(10 * time.Second),
+	}
+
+	testEndpoint, err := url.Parse(fmt.Sprintf("https://%s%s", microsoftGraphHost, getMemberObjectsPath))
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		client     *http.Client
+		token      *oauth2.Token
+		endpoint   *url.URL
+		wantErr    bool
+		wantErrIs  error
+		wantErrMsg string
+		wantGroups []string
+	}{
+		{
+			name:       "missing http client",
+			wantErr:    true,
+			wantErrIs:  ErrNilParameter,
+			wantErrMsg: "nil http client",
+		},
+		{
+			name:       "missing oauth2 token",
+			client:     http.DefaultClient,
+			wantErr:    true,
+			wantErrIs:  ErrNilParameter,
+			wantErrMsg: "nil oauth2 token",
+		},
+		{
+			name:       "missing endpoint",
+			client:     http.DefaultClient,
+			token:      testToken,
+			wantErr:    true,
+			wantErrIs:  ErrInvalidParameter,
+			wantErrMsg: "missing endpoint",
+		},
+		{
+			name:       "unauthorized response",
+			client:     testGraphClient(http.StatusUnauthorized, ""),
+			token:      testToken,
+			endpoint:   testEndpoint,
+			wantErr:    true,
+			wantErrMsg: "graph API request failed with status 401",
+		},
+		{
+			name:       "bad response body",
+			client:     testGraphClient(http.StatusOK, "invalid json response data"),
+			token:      testToken,
+			endpoint:   testEndpoint,
+			wantErr:    true,
+			wantErrMsg: "failed to unmarshal the graph API response body",
+		},
+		{
+			name:       "valid response",
+			client:     testGraphClient(http.StatusOK, `{"value":["group1","group2"]}`),
+			token:      testToken,
+			endpoint:   testEndpoint,
+			wantGroups: []string{"group1", "group2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := fetchGroupIDs(t.Context(), tc.client, tc.token, tc.endpoint)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(t, err, tc.wantErrIs)
+				}
+				if tc.wantErrMsg != "" {
+					assert.ErrorContains(t, err, tc.wantErrMsg)
+				}
+				assert.Nil(t, res)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantGroups, res)
+		})
+	}
+}
+
+func Test_ResolveGroupClaims(t *testing.T) {
+	t.Parallel()
+
+	testToken := &oauth2.Token{
+		AccessToken: "test-access-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(10 * time.Second),
+	}
+
+	testCases := []struct {
+		name       string
+		client     *http.Client
+		token      *oauth2.Token
+		claims     map[string]any
+		wantErr    bool
+		wantErrIs  error
+		wantErrMsg string
+		wantClaims map[string]any
+	}{
+		{
+			name:       "nil http client",
+			token:      testToken,
+			claims:     testOverageClaims(t, microsoftGraphHost),
+			wantErr:    true,
+			wantErrIs:  ErrNilParameter,
+			wantErrMsg: "nil http client",
+		},
+		{
+			name:       "nil oauth2 token",
+			client:     http.DefaultClient,
+			claims:     testOverageClaims(t, microsoftGraphHost),
+			wantErr:    true,
+			wantErrIs:  ErrNilParameter,
+			wantErrMsg: "nil oauth2 token",
+		},
+		{
+			name:       "nil claims map",
+			client:     http.DefaultClient,
+			token:      testToken,
+			wantErr:    true,
+			wantErrIs:  ErrNilParameter,
+			wantErrMsg: "nil claims map",
+		},
+		{
+			name:       "empty claims",
+			client:     http.DefaultClient,
+			token:      testToken,
+			claims:     map[string]any{},
+			wantClaims: map[string]any{},
+		},
+		{
+			name:       "no overage claim",
+			client:     http.DefaultClient,
+			token:      testToken,
+			claims:     map[string]any{"sub": "user1"},
+			wantClaims: map[string]any{},
+		},
+		{
+			name:       "graph API unauthorized",
+			client:     testGraphClient(http.StatusUnauthorized, ""),
+			token:      testToken,
+			claims:     testOverageClaims(t, microsoftGraphHost),
+			wantErr:    true,
+			wantErrMsg: "failed to fetch group IDs from graph API",
+		},
+		{
+			name:       "graph API invalid body",
+			client:     testGraphClient(http.StatusOK, "not json"),
+			token:      testToken,
+			claims:     testOverageClaims(t, microsoftGraphHost),
+			wantErr:    true,
+			wantErrMsg: "failed to fetch group IDs from graph API",
+		},
+		{
+			name:       "graph API returns no groups",
+			client:     testGraphClient(http.StatusOK, `{"value":[]}`),
+			token:      testToken,
+			claims:     testOverageClaims(t, microsoftGraphHost),
+			wantClaims: map[string]any{"groups": []string{}},
+		},
+		{
+			name:       "graph API returns groups",
+			client:     testGraphClient(http.StatusOK, `{"value":["g1","g2"]}`),
+			token:      testToken,
+			claims:     testOverageClaims(t, microsoftGraphHost),
+			wantClaims: map[string]any{"groups": []string{"g1", "g2"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := ResolveGroupClaims(t.Context(), tc.client, tc.token, tc.claims)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(t, err, tc.wantErrIs)
+				}
+				if tc.wantErrMsg != "" {
+					assert.ErrorContains(t, err, tc.wantErrMsg)
+				}
+				assert.Nil(t, res)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.wantClaims, res)
+		})
+	}
+}

--- a/oidc/azure/docs.go
+++ b/oidc/azure/docs.go
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+/*
+The azure package provides support for resolving Azure Entra ID distributed
+group claims. When a user belongs to more than 200 groups, Azure omits the
+groups claim from the token and includes an overage indicator pointing to the
+Microsoft Graph API instead. For more information on this limitation see
+https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#groups-overage-claim
+
+ResolveGroupClaims detects that overage indicator and fetches the full list of
+group IDs from the Graph API on behalf of the caller.
+*/
+package azure

--- a/oidc/azure/error.go
+++ b/oidc/azure/error.go
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package azure
+
+import "errors"
+
+var (
+	ErrInvalidParameter = errors.New("invalid parameter")
+	ErrNilParameter     = errors.New("nil parameter")
+)


### PR DESCRIPTION
# Overview
This PR adds a new `oidc/azure` package that aims to resolve Azure Entra ID distributed group claims. When a user belongs to more than 200 groups, Azure omits the groups claim from the token and replaces it with an [overage indicator](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#groups-overage-claim) pointing to the Microsoft Graph API. This package exposes logic to detect when an overage is present in a token's claims, and fetch and return the full list of groups associated with the user when present. 

# Changes
- Creation of a `azure` package which contains new function(s) `ResolveGroupClaims` and helper functions for detecting the overage indicator, resolving the correct regional Graph API endpoint, and fetching group IDs. 
   - This package supports various Azure cloud deployment endpoints (both [global and national](https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints)) and resolves [deprecated AAD hosts](https://learn.microsoft.com/en-us/graph/migrate-azure-ad-graph-request-differences) automatically.   
- Addition of sentinel errors within the package to support input checks. 
- Package level doc explaining the overage scenario in Azure for groups, and providing official MSFT docs for when it's trigger and how to resolve them. 