### PR TITLE
feat(oidc): Creation Of New Provider Type Option For Provider Config

### DIFF
--- a/oidc/config.go
+++ b/oidc/config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package oidc
@@ -106,6 +106,11 @@ type Config struct {
 	// provider that doesn't support OIDC discovery. It's probably better to use
 	// NewProvider(...) with discovery whenever possible.
 	ProviderConfig *ProviderConfig
+
+	// ProviderType is an optional identifier for the OIDC provider that enables
+	// provider specific logic. Examples include resolving group overage claims
+	// for Azure.
+	ProviderType ProviderType
 }
 
 // NewConfig composes a new config for a provider.
@@ -130,6 +135,7 @@ func NewConfig(issuer string, clientID string, clientSecret ClientSecret, suppor
 		NowFunc:              opts.withNowFunc,
 		AllowedRedirectURLs:  allowedRedirectURLs,
 		ProviderConfig:       opts.withProviderConfig,
+		ProviderType:         opts.withProviderType,
 	}
 	if err := c.Validate(); err != nil {
 		return nil, fmt.Errorf("%s: invalid provider config: %w", op, err)
@@ -195,6 +201,11 @@ func (c *Config) Hash() (uint64, error) {
 			c.ProviderConfig.UserInfoURL,
 		)
 	}
+
+	if c.ProviderType != "" {
+		args = append(args, string(c.ProviderType))
+	}
+
 	if h, err = hashStrings(args...); err != nil {
 		return 0, fmt.Errorf("hashing error: %w", err)
 	}
@@ -303,6 +314,11 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("%s: missing UserInfoURL: %w", op, ErrInvalidParameter)
 		}
 	}
+
+	if c.ProviderType != "" && !SupportedProviderType(c.ProviderType) {
+		return fmt.Errorf("%s: unsupported provider type %s: %w", op, c.ProviderType, ErrInvalidParameter)
+	}
+
 	return nil
 }
 
@@ -322,6 +338,7 @@ type configOptions struct {
 	withNowFunc        func() time.Time
 	withProviderConfig *ProviderConfig
 	withRoundTripper   http.RoundTripper
+	withProviderType   ProviderType
 }
 
 // configDefaults is a handy way to get the defaults at runtime and
@@ -417,6 +434,16 @@ func WithProviderConfig(cfg *ProviderConfig) Option {
 	return func(o interface{}) {
 		if o, ok := o.(*configOptions); ok {
 			o.withProviderConfig = cfg
+		}
+	}
+}
+
+// WithProviderType provides an optional ProviderType for the Config that
+// enables provider specific behavior.
+func WithProviderType(providerType ProviderType) Option {
+	return func(o interface{}) {
+		if o, ok := o.(*configOptions); ok {
+			o.withProviderType = providerType
 		}
 	}
 }

--- a/oidc/config_test.go
+++ b/oidc/config_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package oidc
@@ -356,6 +356,41 @@ func TestNewConfig(t *testing.T) {
 			wantErr:   true,
 			wantIsErr: ErrInvalidParameter,
 		},
+		{
+			name: "with-provider-type",
+			args: args{
+				issuer:       "http://your_issuer/",
+				clientID:     "your_client_id",
+				clientSecret: "your_client_secret",
+				supported:    []Alg{RS512},
+				opt: []Option{
+					WithProviderType(ProviderTypeAzure),
+				},
+			},
+			want: &Config{
+				Issuer:               "http://your_issuer/",
+				ClientID:             "your_client_id",
+				ClientSecret:         "your_client_secret",
+				SupportedSigningAlgs: []Alg{RS512},
+				Scopes:               []string{oidc.ScopeOpenID},
+				ProviderType:         ProviderTypeAzure,
+			},
+		},
+		{
+			name: "unsupported-provider-type",
+			args: args{
+				issuer:       "http://your_issuer/",
+				clientID:     "your_client_id",
+				clientSecret: "your_client_secret",
+				supported:    []Alg{RS512},
+				opt: []Option{
+					WithProviderType(ProviderType("unknown")),
+				},
+			},
+			wantErr:         true,
+			wantIsErr:       ErrInvalidParameter,
+			wantErrContains: "unsupported provider type",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -380,6 +415,7 @@ func TestNewConfig(t *testing.T) {
 			assert.Equalf(tt.want.ProviderCA, got.ProviderCA, "ProviderCA = %v, want %v", got.ProviderCA, tt.want.ProviderCA)
 			testAssertEqualFunc(t, tt.want.NowFunc, got.NowFunc, "NowFunc = %p,want %p", tt.want.NowFunc, got.NowFunc)
 			assert.Equalf(tt.want.AllowedRedirectURLs, got.AllowedRedirectURLs, "AllowedRedirectURLs = %v, want %v", got.AllowedRedirectURLs, tt.want.AllowedRedirectURLs)
+			assert.Equalf(tt.want.ProviderType, got.ProviderType, "ProviderType = %v, want %v", got.ProviderType, tt.want.ProviderType)
 		})
 	}
 }
@@ -393,6 +429,19 @@ func TestConfig_Validate(t *testing.T) {
 		var c *Config
 		err := c.Validate()
 		assert.Truef(errors.Is(err, ErrNilParameter), "Config.Validate() = %v, want %v", err, ErrNilParameter)
+	})
+	t.Run("unsupported-provider-type", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		c := &Config{
+			Issuer:               "http://your_issuer/",
+			ClientID:             "your_client_id",
+			ClientSecret:         "your_client_secret",
+			SupportedSigningAlgs: []Alg{RS512},
+			ProviderType:         ProviderType("unknown"),
+		}
+		err := c.Validate()
+		require.Error(err)
+		assert.Truef(errors.Is(err, ErrInvalidParameter), "Config.Validate() = %v, want %v", err, ErrInvalidParameter)
 	})
 }
 
@@ -956,6 +1005,57 @@ func TestConfig_Hash(t *testing.T) {
 			),
 			wantEqual: false,
 		},
+		{
+			name: "diff-provider-type",
+			c1: newCfg(
+				"https://www.alice.com",
+				"client-id", "client-secret",
+				[]Alg{RS256},
+				[]string{"www.alice.com/callback"},
+				WithScopes("email", "profile"),
+				WithAudiences("alice.com", "bob.com"),
+				WithProviderCA(pem),
+				WithNow(time.Now),
+				WithProviderType(ProviderTypeAzure),
+			),
+			c2: newCfg(
+				"https://www.alice.com",
+				"client-id", "client-secret",
+				[]Alg{RS256},
+				[]string{"www.alice.com/callback"},
+				WithScopes("email", "profile"),
+				WithAudiences("alice.com", "bob.com"),
+				WithProviderCA(pem),
+				WithNow(time.Now),
+			),
+			wantEqual: false,
+		},
+		{
+			name: "equal-with-provider-type",
+			c1: newCfg(
+				"https://www.alice.com",
+				"client-id", "client-secret",
+				[]Alg{RS256},
+				[]string{"www.alice.com/callback"},
+				WithScopes("email", "profile"),
+				WithAudiences("alice.com", "bob.com"),
+				WithProviderCA(pem),
+				WithNow(time.Now),
+				WithProviderType(ProviderTypeAzure),
+			),
+			c2: newCfg(
+				"https://www.alice.com",
+				"client-id", "client-secret",
+				[]Alg{RS256},
+				[]string{"www.alice.com/callback"},
+				WithScopes("email", "profile"),
+				WithAudiences("alice.com", "bob.com"),
+				WithProviderCA(pem),
+				WithNow(time.Now),
+				WithProviderType(ProviderTypeAzure),
+			),
+			wantEqual: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -976,6 +1076,15 @@ func TestConfig_Hash(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_WithProviderType(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	opts := getConfigOpts(WithProviderType(ProviderTypeAzure))
+	testOpts := configDefaults()
+	testOpts.withProviderType = ProviderTypeAzure
+	assert.Equal(opts, testOpts)
 }
 
 type testRoundTripper struct {

--- a/oidc/provider_type.go
+++ b/oidc/provider_type.go
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package oidc
+
+// ProviderType identifies a given known OIDC provider.
+type ProviderType string
+
+const (
+	// ProviderTypeAzure is the provider identifier for Microsoft Azure.
+	ProviderTypeAzure ProviderType = "azure"
+)
+
+// supportedProviderTypes is a map of known OIDC provider types.
+var supportedProviderTypes = map[ProviderType]bool{
+	ProviderTypeAzure: true,
+}
+
+// SupportedProviderType returns true if the given provider type is known and supported.
+func SupportedProviderType(p ProviderType) bool {
+	return supportedProviderTypes[p]
+}

--- a/oidc/provider_type_test.go
+++ b/oidc/provider_type_test.go
@@ -1,0 +1,48 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package oidc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupportedProviderType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		provider ProviderType
+		want     bool
+	}{
+		{
+			name:     "supported azure provider",
+			provider: ProviderTypeAzure,
+			want:     true,
+		},
+		{
+			name:     "empty provider",
+			provider: ProviderType(""),
+			want:     false,
+		},
+		{
+			name:     "unsupported google provider",
+			provider: ProviderType("google"),
+			want:     false,
+		},
+		{
+			name:     "unknown provider",
+			provider: ProviderType("unknown"),
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SupportedProviderType(tt.provider)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
# Overview
This PR adds a new optional `ProviderType` field to the OIDC Config struct. The purpose of this option is to allow callers to identify which OIDC provider they are configuring so that provider specific logic can be triggered in cap. 

Currently the only initial supported type is `Azure`, which will enable in the future resolving group overage claims.

# Changes
- Creation of a new file `provider_type.go` within the oidc package which contains the following: 
   -  `ProviderType` string type
   -  `ProviderTypeAzure` constant to denote the `Azure` provider
   - A `SupportedProviderType` helper function that validates if a given provider type is supported within the library
- Addition of the `ProviderType` field to the `Config` struct in addition to the `WithProviderType` option function that sets `ProviderType` on a `Config` during construction.
- Modification of the `Config` methods: 
   - `Validate` which now rejects and throws an error any non-empty provider type `ProviderType` supplied that is not currently known and supported. 
   - `Hash` adds the `ProviderType` in the hash input to be computed, such that the hash is consistent across all config fields. 