### PR TITLE
saml: close the IdP metadata HTTP response body

### DIFF
--- a/saml/sp.go
+++ b/saml/sp.go
@@ -318,6 +318,7 @@ func fetchIDPMetadata(metadataURL string) (*metadata.EntityDescriptorIDPSSO, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch identity provider metadata: %w", err)
 	}
+	defer res.Body.Close()
 
 	raw, err := io.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
`fetchIDPMetadata` (`saml/sp.go`) reads `res.Body` via `io.ReadAll` but never closes it, so the response body / connection leaks. The two other HTTP fetch sites in this repo already handle this correctly — `oidc/provider.go` and `jwt/keyset.go` both `defer resp.Body.Close()`. This adds the same `defer res.Body.Close()` right after the successful `http.Get`.

One-line change; `go build ./saml/` passes.
