### PR TITLE
feat(oidc): Resolve Additional Provider Resolved Claims On Tk

### DIFF
--- a/oidc/token.go
+++ b/oidc/token.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package oidc
@@ -53,6 +53,10 @@ type Tk struct {
 
 	// nowFunc is an optional function that returns the current time
 	nowFunc func() time.Time
+
+	// additionalClaims holds resolved claims that are populated post OIDC exchange for
+	// provider specific resolution that cannot be written back into the signed id_token.
+	additionalClaims map[string]any
 }
 
 // ensure that Tk implements the Token interface
@@ -70,9 +74,10 @@ func NewToken(i IDToken, t *oauth2.Token, opt ...Option) (*Tk, error) {
 	}
 	opts := getTokenOpts(opt...)
 	return &Tk{
-		idToken:    i,
-		underlying: t,
-		nowFunc:    opts.withNowFunc,
+		idToken:          i,
+		underlying:       t,
+		nowFunc:          opts.withNowFunc,
+		additionalClaims: make(map[string]any),
 	}, nil
 }
 
@@ -148,6 +153,34 @@ func (t *Tk) now() time.Time {
 		return t.nowFunc()
 	}
 	return time.Now() // fallback to this default
+}
+
+// EffectiveClaims merges additionalClaims and the id_token claims into v.
+// id_token claims take precedence over any overlapping keys in additionalClaims.
+//
+// Overage and/or distributed claims in the id_token are not removed.
+// When a OIDC provider is configured, such as the Azure provider, overage claims
+// are automatically resolved during exchange and require no additional resolution
+// from the caller.
+func (t *Tk) EffectiveClaims(v any) error {
+	const op = "Tk.EffectiveClaims"
+	if v == nil {
+		return fmt.Errorf("%s: v is nil: %w", op, ErrNilParameter)
+	}
+	if t.idToken == "" {
+		return fmt.Errorf("%s: id_token is empty: %w", op, ErrInvalidParameter)
+	}
+
+	if len(t.additionalClaims) > 0 {
+		b, err := json.Marshal(t.additionalClaims)
+		if err != nil {
+			return fmt.Errorf("%s: unable to marshal additional claims: %w", op, err)
+		}
+		if err := json.Unmarshal(b, v); err != nil {
+			return fmt.Errorf("%s: unable to unmarshal additional claims: %w", op, err)
+		}
+	}
+	return t.idToken.Claims(v)
 }
 
 // tokenOptions is the set of available options for Token functions

--- a/oidc/token_test.go
+++ b/oidc/token_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2020, 2025
+// Copyright IBM Corp. 2020, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package oidc
@@ -57,9 +57,10 @@ func TestNewToken(t *testing.T) {
 			oauthToken: testUnderlying,
 			opts:       []Option{WithNow(testNow)},
 			want: &Tk{
-				idToken:    IDToken(testJWT),
-				underlying: testUnderlying,
-				nowFunc:    testNow,
+				idToken:          IDToken(testJWT),
+				underlying:       testUnderlying,
+				nowFunc:          testNow,
+				additionalClaims: map[string]any{},
 			},
 			wantIDToken:      IDToken(testJWT),
 			wantAccessToken:  AccessToken(testAccessToken),
@@ -75,8 +76,9 @@ func TestNewToken(t *testing.T) {
 			oauthToken: testUnderlying,
 			opts:       []Option{},
 			want: &Tk{
-				idToken:    IDToken(testJWT),
-				underlying: testUnderlying,
+				idToken:          IDToken(testJWT),
+				underlying:       testUnderlying,
+				additionalClaims: map[string]any{},
 			},
 			wantIDToken:      IDToken(testJWT),
 			wantAccessToken:  AccessToken(testAccessToken),
@@ -90,7 +92,8 @@ func TestNewToken(t *testing.T) {
 			name:    "valid-without-accessToken",
 			idToken: IDToken(testJWT),
 			want: &Tk{
-				idToken: IDToken(testJWT),
+				idToken:          IDToken(testJWT),
+				additionalClaims: map[string]any{},
 			},
 			wantIDToken: IDToken(testJWT),
 			wantExpired: true,
@@ -101,8 +104,9 @@ func TestNewToken(t *testing.T) {
 			idToken:    IDToken(testJWT),
 			oauthToken: testUnderlyingZeroExpiry,
 			want: &Tk{
-				idToken:    IDToken(testJWT),
-				underlying: testUnderlyingZeroExpiry,
+				idToken:          IDToken(testJWT),
+				underlying:       testUnderlyingZeroExpiry,
+				additionalClaims: map[string]any{},
 			},
 			wantIDToken:      IDToken(testJWT),
 			wantAccessToken:  AccessToken(testAccessToken),
@@ -155,5 +159,89 @@ func TestUnmarshalClaims(t *testing.T) {
 		err := UnmarshalClaims(jwt, &claims)
 		require.Error(err)
 		assert.Truef(errors.Is(err, ErrInvalidParameter), "wanted \"%s\" but got \"%s\"", ErrInvalidParameter, err)
+	})
+}
+
+func TestEffectiveClaims(t *testing.T) {
+	t.Parallel()
+
+	_, priv := TestGenerateKeys(t)
+	testIat := float64(time.Now().Unix())
+	testExp := float64(time.Now().Add(10 * time.Minute).Unix())
+	testJWT := TestSignJWT(t, priv, string(ES256), map[string]any{
+		"iss": "https://example.com/",
+		"iat": testIat,
+		"exp": testExp,
+		"aud": []string{"www.example.com"},
+		"sub": "alice@example.com",
+	}, nil)
+
+	t.Run("nil-claims", func(t *testing.T) {
+		t.Parallel()
+		tk := &Tk{idToken: IDToken(testJWT), additionalClaims: map[string]any{}}
+		err := tk.EffectiveClaims(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNilParameter)
+		assert.ErrorContains(t, err, "v is nil")
+	})
+	t.Run("empty-id-token", func(t *testing.T) {
+		t.Parallel()
+		tk := &Tk{idToken: IDToken(""), additionalClaims: map[string]any{}}
+		var claims map[string]any
+		err := tk.EffectiveClaims(&claims)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidParameter)
+		assert.ErrorContains(t, err, "id_token is empty")
+	})
+	t.Run("no-additional-claims", func(t *testing.T) {
+		t.Parallel()
+		tk := &Tk{idToken: IDToken(testJWT), additionalClaims: map[string]any{}}
+		var claims map[string]any
+		err := tk.EffectiveClaims(&claims)
+		require.NoError(t, err)
+		assert.EqualValues(t, map[string]any{
+			"iss": "https://example.com/",
+			"iat": testIat,
+			"exp": testExp,
+			"aud": []any{"www.example.com"},
+			"sub": "alice@example.com",
+		}, claims)
+	})
+	t.Run("azure-groups-overage", func(t *testing.T) {
+		t.Parallel()
+		tk := &Tk{
+			idToken: IDToken(testJWT),
+			additionalClaims: map[string]any{
+				"groups": []any{"group-a", "group-b"},
+			},
+		}
+		var claims map[string]any
+		err := tk.EffectiveClaims(&claims)
+		require.NoError(t, err)
+		assert.EqualValues(t, map[string]any{
+			"iss":    "https://example.com/",
+			"iat":    testIat,
+			"exp":    testExp,
+			"aud":    []any{"www.example.com"},
+			"sub":    "alice@example.com",
+			"groups": []any{"group-a", "group-b"},
+		}, claims)
+	})
+	t.Run("id-token-wins-conflict", func(t *testing.T) {
+		t.Parallel()
+		tk := &Tk{
+			idToken:          IDToken(testJWT),
+			additionalClaims: map[string]any{"sub": "alice2@example.com"},
+		}
+		var claims map[string]any
+		err := tk.EffectiveClaims(&claims)
+		require.NoError(t, err)
+		assert.EqualValues(t, map[string]any{
+			"iss": "https://example.com/",
+			"iat": testIat,
+			"exp": testExp,
+			"aud": []any{"www.example.com"},
+			"sub": "alice@example.com",
+		}, claims)
 	})
 }


### PR DESCRIPTION
# Overview
This PR adds an `EffectiveClaims` method to the `Tk` struct along with the `additionalClaims` field. The purpose of the additions is to give callers a single way to retrieve a complete merged view of all claims on a token, including any claims resolved outside of the signed `id_token` during the OIDC exchange, such as groups fetched from an Azure Entra overage endpoint.

# Changes
- Creation and allocation of the new `additionalClaims` field on the `Tk` struct to hold resolved claims after an OIDC exchange, such as groups resolved from an Azure overage endpoint.
- Addition of the `EffectiveClaims(...)` method on `Tk` which merges `additionalClaims` with the claims stored within the `id_token`. 
   - In the case their are duplicate claims keys for both, the `id_token` is merged on top of the `additionalClaims` field, such that any claims found in the signed `id_token` overwrite any provided by post exchange claim resolutions. This ensures that the verified signed claims always win any convict. 
